### PR TITLE
Pass host HF_TOKEN into the weight download container

### DIFF
--- a/scripts/download-weights.sh
+++ b/scripts/download-weights.sh
@@ -12,11 +12,23 @@ IMAGE="${IMAGE:-qwen38-flash-dgx}"          # or the upstream image; only needs 
 HF_CACHE="${HF_CACHE:-$HOME/.cache/huggingface}"
 mkdir -p "$HF_CACHE"
 
+# hf authenticates via HF_TOKEN (or the older HUGGING_FACE_HUB_TOKEN name).
+# docker -e NAME (no value) copies the host env var into the container.
+TOKEN_ARGS=()
+if [ -n "${HF_TOKEN:-}" ]; then
+  TOKEN_ARGS+=(-e HF_TOKEN)
+elif [ -n "${HUGGING_FACE_HUB_TOKEN:-}" ]; then
+  TOKEN_ARGS+=(-e HUGGING_FACE_HUB_TOKEN -e HF_TOKEN="$HUGGING_FACE_HUB_TOKEN")
+else
+  echo ">> no HF_TOKEN in the environment; Hub will rate-limit unauthenticated downloads"
+fi
+
 echo ">> downloading $MODEL into $HF_CACHE (resumable)"
 # HF_HUB_DISABLE_XET=1: the Xet backend stalled on some Spark setups; plain HTTPS
 # is reliable and saturates the link.
 docker run --rm --name qwen38-dl \
   -e HF_HOME=/hf -e HF_HUB_DISABLE_XET=1 \
+  "${TOKEN_ARGS[@]}" \
   -v "$HF_CACHE:/hf" --entrypoint bash "$IMAGE" \
   -c "hf download '$MODEL' --max-workers 8"
 


### PR DESCRIPTION
## Summary
- Forward `HF_TOKEN` (or `HUGGING_FACE_HUB_TOKEN`) from the host into the `qwen38-dl` container so `hf download` authenticates.
- Warn when neither token is set, instead of silently hitting Hub rate limits.

## Test plan
- [ ] With `HF_TOKEN` exported, run `scripts/download-weights.sh` and confirm the unauthenticated Hub warning is gone.
- [ ] Without `HF_TOKEN` or `HUGGING_FACE_HUB_TOKEN`, confirm the script still starts and prints the missing-token warning.


Made with [Cursor](https://cursor.com)