### PR TITLE
hybrid-mtp: graft the NVFP4 MTP draft experts (Inferact) onto the hyb…

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ full comparison tables are in [docs/HOW-IT-WORKS.md](docs/HOW-IT-WORKS.md).*
 
 - An **NVIDIA DGX Spark or compatible GB10 (sm_121)** box, 128 GB unified memory,
   aarch64, recent NVIDIA driver, Docker with the NVIDIA container runtime.
-- **~140 GB free disk** for the checkpoint (+13 GB for the hybrid variant), on
+- **~140 GB free disk** for the checkpoint (+13 GB for the hybrid variant, +5 GB more
+  for the NVFP4-MTP graft), on
   reasonably fast storage (the table is read from it at runtime — NVMe strongly
   recommended; the Spark's onboard NVMe is ideal).
 - The base image is multi-arch, so `docker build` also works on x86 Blackwell
@@ -177,6 +178,45 @@ MODE=hybrid YARN=1 CTX=500000 GPU_MEM=0.80 scripts/serve.sh
 
 Our own box runs the hybrid. If you want the checkpoint exactly as published, stay on
 `MODE=nvfp4` — you lose ~5 tok/s and nothing else.
+
+### NVFP4 MTP draft experts (`MODE=hybrid-mtp`)
+
+A graft on top of the hybrid: the MTP draft head's routed experts (BF16 fused, ~4.7 GiB)
+are replaced by the **NVFP4** draft experts from
+[Inferact/Qwen3.8-Flash-Next-NVFP4](https://huggingface.co/Inferact/Qwen3.8-Flash-Next-NVFP4)
+(1.4 GiB) — the combination neither parent ships: fp8 PLE table *and* a cheap draft.
+`scripts/prepare-mtp-graft.sh` builds it in ~5 min (~3.3 GB of real bytes: one shard
+rewritten without the 2 fused BF16 MTP tensors, a symlink to the donor shard, and the
+index + both quantization exclusion lists fixed — the blanket `mtp.*` globs are replaced
+by the donor's 29 explicit non-expert MTP module names in **both** `config.json` and
+`hf_quant_config.json`, or the draft loads unquantized and dies). Both parents are
+modelopt quantizations of the same base — verified by hashing `embed_tokens.weight` and
+all 29 shared draft tensors byte-for-byte before grafting. The graft reads through both
+parents (it is a directory of symlinks); don't delete either one.
+
+Measured on the GX10 (hybrid, MTP=2, greedy, real answers):
+
+| | `MODE=hybrid` | `MODE=hybrid-mtp` |
+|---|---|---|
+| Weights on card | 77.83 GiB | **74.75 GiB** (−3.1) |
+| KV cache @0.80 | 625,669 tok | **734,292 tok (+17%)** |
+| Max concurrency @262k | 2.39x | **2.80x** |
+| Decode, 5-prompt greedy probe | 26.6–33.8 tok/s | **34.7–42.5 tok/s (+20–27%)** |
+| Mean acceptance length | ~2.73 | ~2.58 (same band) |
+| Tournament quality | 45/51 | same target model, byte-identical greedy outputs (see below) |
+
+The draft swap is gated on **greedy output equivalence**: every emitted token is the
+target model's argmax (the draft only decides how many of its proposals get accepted per
+step), so `scripts/greedy-probe.sh <label>` run against both arms must produce
+byte-identical text. It does — 5/5 prompts, 400 tokens each, first-token logprobs
+identical to 4 decimals — and the faster draft is pure win: the same verification cost,
+~4x fewer bytes read per draft step. Donor revision is pinned
+(`103a7608…`, sha256 `0d44e6d7…`); a different donor revision needs re-gating.
+
+```bash
+scripts/prepare-mtp-graft.sh              # one-time, after prepare-hybrid.sh
+MODE=hybrid-mtp scripts/serve.sh
+```
 
 ## Prefix caching now works (and why it didn't)
 
@@ -430,8 +470,10 @@ src/test_qsa_exact_topk_cpu.py    CPU unit test for the exact top-k (no GPU need
 tools/fp8_convert.py              side-layer bf16 -> blockwise fp8 (by @Saren-Arterius)
 scripts/download-weights.sh
 scripts/prepare-hybrid.sh         one-time: build the -fp8hybrid snapshot
-scripts/serve.sh                  MODE=nvfp4|hybrid, PREFIX_CACHE, DET_TOPK, EXACT_TOPK, PAD_M4, KV_DTYPE, YARN, ...
+scripts/prepare-mtp-graft.sh      one-time: graft the NVFP4 MTP draft experts onto it
+scripts/serve.sh                  MODE=nvfp4|hybrid|hybrid-mtp, PREFIX_CACHE, DET_TOPK, EXACT_TOPK, PAD_M4, KV_DTYPE, YARN, ...
 scripts/smoke-test.sh             health, coherence, prefix-cache hit, determinism, tok/s
+scripts/greedy-probe.sh           greedy probe set; diff two arms to gate a draft/checkpoint swap
 docs/HOW-IT-WORKS.md
 ```
 
@@ -465,6 +507,9 @@ docker run --rm -v "$PWD/src:/t" -w /t --entrypoint python3 qwen38-flash-dgx tes
 
 - Model: **Qwen team, Alibaba** — Qwen3.8-Flash-Next.
 - NVFP4 checkpoint: **[RadixArk/Qwen3.8-Flash-Next-NVFP4](https://huggingface.co/RadixArk/Qwen3.8-Flash-Next-NVFP4)**.
+- NVFP4 MTP draft experts (the `hybrid-mtp` graft donor): **[Inferact/Qwen3.8-Flash-Next-NVFP4](https://huggingface.co/Inferact/Qwen3.8-Flash-Next-NVFP4)**; the graft recipe follows
+  [thavoc's graft write-up](https://gist.github.com/thavoc/d7083457f6f2d981f879670c34df34ab)
+  and [Peuqui/mtp-quant-transplant](https://github.com/Peuqui/mtp-quant-transplant).
 - Serving engine and base image: **vLLM** (`vllm/vllm-openai:qwen38-flash-next`,
   the `release/qwen38next` recipe / PR #53896); the Mamba state-copy race fix is
   [vllm#50729](https://github.com/vllm-project/vllm/pull/50729) by **@AndreasKaratzas**.

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -359,6 +359,44 @@ The Intel AutoRound variant is fastest at raw decode but could not be made
 deterministic and has the worst cached-TTFT (its prefill is the slowest), so we did not
 adopt it; the numbers are here for completeness.
 
+### The NVFP4 MTP draft graft (`MODE=hybrid-mtp`)
+
+The hybrid keeps the checkpoint's MTP draft head as published: routed experts **fused
+BF16** (`mtp.layers.0.mlp.experts.{down_proj,gate_up_proj}`, shapes `(512,1280,2560)` and
+`(512,2560,640)`, ~4.7 GiB). The draft is read on every speculation step, so it is the
+same bandwidth story as the side layers — but it is also 3 GiB of card that spec decoding
+pays for in KV. [Inferact's](https://huggingface.co/Inferact/Qwen3.8-Flash-Next-NVFP4)
+checkpoint of the same base quantizes the draft experts per-expert NVFP4
+(6,144 tensors: `…experts.{E}.{gate_proj,up_proj,down_proj}.{weight,weight_scale,
+weight_scale_2,input_scale}`, 1.4 GiB). `scripts/prepare-mtp-graft.sh` grafts that block
+onto the `-fp8hybrid` snapshot (see the README section for the mechanics and the two
+exclude-list traps). Mechanically the swap is safe because the engine's
+`RoutedExperts.load_weights` builds its mapping with `include_fused=True` and dispatches
+per tensor on rank (3D = fused, 2D = per-expert), so both layouts load through one code
+path; the draft's quant config is resolved from the checkpoint's own `hf_quant_config.json`,
+renumbered by vLLM (`mtp.layers.0` → `mtp.layers.48` on the engine side) and matched with
+substring rules, which is why the 29 explicit module names work in both spellings.
+
+Three properties hold, all verified on the GX10:
+
+- **The target model is untouched.** Its loader skips everything under `mtp.`
+  (`skip_substrs=["mtp."]`), so the 6,144 new tensors never reach it; the fp8 dispatch
+  still detects exactly the same 300 side layers.
+- **Every emitted token is the target's argmax.** Greedy verification accepts a draft
+  token only when it matches the target's argmax, so the output text is a property of the
+  target alone. `scripts/greedy-probe.sh` against the BF16-MTP arm and the graft produces
+  byte-identical text (5/5 prompts × 400 tokens, first-token logprobs identical to 4
+  decimals) — a silently mispaired drafter would fail this.
+- **Acceptance stays in the same band** (~2.6 vs ~2.7 mean acceptance length at MTP=2):
+  the NVFP4 draft proposes marginally differently, rejected proposals cost nothing extra,
+  and the decode win comes from the ~4x smaller draft reads.
+
+Measured (same box, same defaults as the table above, MTP=2): weights 77.83 → 74.75 GiB,
+KV pool 625,669 → 734,292 tokens (+17%), greedy decode +20–27% on the 5-prompt probe.
+One caveat inherited from the graft design: the graft directory holds symlinks into *both*
+parent snapshots plus the Inferact blob — HF cache tooling cannot see that, so do not
+prune either parent.
+
 
 ### The blockwise-fp8 GEMM's `M % 4` slow path (patch 9, opt-in)
 

--- a/scripts/greedy-probe.sh
+++ b/scripts/greedy-probe.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Greedy probe set — the gate for the NVFP4-MTP graft (scripts/prepare-mtp-graft.sh):
+# run it against a BF16-MTP arm (MODE=hybrid) and the graft (MODE=hybrid-mtp), then diff
+# the two JSON files. Greedy output must be byte-identical: every emitted token is the
+# target model's argmax (the draft only changes how many tokens are accepted per step),
+# so a diverging text means a mispaired drafter, not a quantization artefact.
+#   scripts/greedy-probe.sh <label> [host:port]     # writes ~/q38-tmp/gate/<label>.json
+set -euo pipefail
+LABEL="${1:?usage: greedy-probe.sh <label> [host:port]}"
+EP="${2:-localhost:18300}"
+mkdir -p "$HOME/q38-tmp/gate"
+python3 - "$EP" "$HOME/q38-tmp/gate/$LABEL.json" <<'PY'
+import json, sys, time, urllib.request
+base, out = sys.argv[1], sys.argv[2]
+if not base.startswith("http"):
+    base = "http://" + base
+prompts = [
+    "The capital of France is",
+    "Write a haiku about a desktop supercomputer. /no_think",
+    "Explain in about 300 words how a page cache works and why random reads from an NVMe-backed mmap get faster over time. /no_think",
+    "Write a Python function that checks whether a string is a palindrome, with a docstring. /no_think",
+    "Summarize the plot of Hamlet in four sentences, then name the speaker of 'To be, or not to be'. /no_think",
+]
+results = []
+for i, p in enumerate(prompts):
+    body = {"model": "qwen3.8-flash-next", "prompt": p, "max_tokens": 400,
+            "temperature": 0, "logprobs": 3}
+    t = time.time()
+    req = urllib.request.Request(base + "/v1/completions", data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    r = json.load(urllib.request.urlopen(req, timeout=900))
+    c = r["choices"][0]
+    results.append({"prompt": p, "text": c["text"], "tokens": r["usage"]["completion_tokens"],
+                    "seconds": round(time.time() - t, 2),
+                    "tok_s": round(r["usage"]["completion_tokens"] / (time.time() - t), 2),
+                    "first_logprobs": (c.get("logprobs") or {}).get("top_logprobs", [None])[0]})
+    print(f"   [{i}] {results[-1]['tokens']} tok in {results[-1]['seconds']}s "
+          f"({results[-1]['tok_s']} tok/s)")
+json.dump(results, open(out, "w"), indent=1)
+print(f">> wrote {out}")
+PY

--- a/scripts/prepare-mtp-graft.sh
+++ b/scripts/prepare-mtp-graft.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# One-time graft of the NVFP4 MTP draft experts (Inferact/Qwen3.8-Flash-Next-NVFP4,
+# nvfp4_experts_mtp.safetensors) on top of the -fp8hybrid checkpoint — the combination
+# neither parent ships: fp8 PLE table (48 GiB mmap'd from disk instead of resident)
+# plus NVFP4 MTP draft experts. No retraining, no requantization.
+#
+#   scripts/prepare-mtp-graft.sh         # needs scripts/prepare-hybrid.sh first; ~5 min, ~3.4 GB
+#   MODE=hybrid-mtp scripts/serve.sh
+#
+# What the graft changes relative to the -fp8hybrid snapshot it builds on:
+#   - model-bf16-00011.safetensors: rewritten WITHOUT the 2 fused BF16 MTP expert
+#     tensors (mtp.layers.0.mlp.experts.{down_proj,gate_up_proj}, ~5 GB). They must
+#     not reach the loader alongside the per-expert NVFP4 tensors: the weight
+#     iterator walks whole files (the index only selects files, not tensors), so
+#     dropping the keys from the index alone is not enough.
+#   - +6,144 NVFP4 per-expert MTP tensors, symlinked from the donor repo
+#     (same per-expert naming/layout as the main-model experts the engine already
+#     loads; RoutedExperts.load_weights accepts both layouts in one mapping).
+#   - model.safetensors.index.json: -2 fused keys, +6,144 donor keys.
+#   - config.json AND hf_quant_config.json: the blanket "mtp.*"/"model.mtp.*"
+#     exclusion globs (which keep the whole draft head in BF16) are replaced by the
+#     donor's 29 explicit non-expert MTP module names, so the routed experts are
+#     quantized while everything else under mtp. stays full-width. BOTH lists must
+#     carry the fix: the draft's quant config and the target's read different files,
+#     and fixing only one leaves the MTP unquantized (load dies on missing
+#     'w2_input_scale' / fused-tensor shape asserts). The globs cannot simply be
+#     deleted: that would quantize the draft's attention, shared expert and fc_*
+#     linears, whose tensors are BF16 (mtp.fc_embedding / mtp.fc_hidden are not
+#     covered by any remaining pattern).
+#
+# Layout: a sibling of the hybrid snapshot made of relative symlinks (into the
+# hybrid snapshot and through the cache root to the Inferact blob), so it resolves
+# inside the container under /hf. Nothing in either parent snapshot is touched.
+# Method: https://gist.github.com/thavoc/d7083457f6f2d981f879670c34df34ab and
+# https://github.com/Peuqui/mtp-quant-transplant.
+set -euo pipefail
+
+MODEL="${MODEL:-RadixArk/Qwen3.8-Flash-Next-NVFP4}"
+IMAGE="${IMAGE:-qwen38-flash-dgx}"
+HF_CACHE="${HF_CACHE:-$HOME/.cache/huggingface}"
+
+REPO_DIR="$HF_CACHE/hub/models--${MODEL//\//--}"
+# Same revision resolution as scripts/serve.sh and scripts/prepare-hybrid.sh.
+SNAP_HOST=""
+for REF in main master; do
+  REV="$(cat "$REPO_DIR/refs/$REF" 2>/dev/null || true)"
+  if [ -n "$REV" ] && [ -d "$REPO_DIR/snapshots/$REV" ]; then SNAP_HOST="$REPO_DIR/snapshots/$REV/"; break; fi
+done
+SNAP_HOST="${SNAP_HOST:-$(ls -dt "$REPO_DIR"/snapshots/*/ 2>/dev/null | grep -v -- '-fp8hybrid' | head -1 || true)}"
+[ -n "$SNAP_HOST" ] || { echo "!! checkpoint not found under $REPO_DIR — run scripts/download-weights.sh first"; exit 1; }
+SNAP_NAME="$(basename "$SNAP_HOST")"
+HYBRID_NAME="${SNAP_NAME}-fp8hybrid"
+GRAFT_NAME="${HYBRID_NAME}-mtpnvfp4"
+[ -f "$REPO_DIR/snapshots/$HYBRID_NAME/.prepared" ] || {
+  echo "!! hybrid checkpoint not prepared: run scripts/prepare-hybrid.sh first (one-time, ~10 min)"; exit 1; }
+[ -f "$REPO_DIR/snapshots/$GRAFT_NAME/.prepared" ] && { echo ">> already prepared: $REPO_DIR/snapshots/$GRAFT_NAME"; exit 0; }
+
+echo ">> grafting the NVFP4 MTP experts onto $HYBRID_NAME (downloads a 1.5 GiB donor shard once)"
+docker run --rm -i --name qwen38-mtp-graft \
+  -v "$HF_CACHE:/hf" --entrypoint python3 "$IMAGE" -u - <<'PYEOF'
+import hashlib, json, os, re, struct, sys, urllib.request
+
+REPO = "/hf/hub/models--RadixArk--Qwen3.8-Flash-Next-NVFP4"
+DONOR = "/hf/hub/models--Inferact--Qwen3.8-Flash-Next-NVFP4"
+DONOR_REV = "103a7608316173ca6edd49929544244de7ffda70"
+DONOR_SHA = "0d44e6d705d2313c713e60114e56874adf358ed5f646dc8704bb5be15f5ddbf7"
+hybrids = sorted(d for d in os.listdir(f"{REPO}/snapshots") if d.endswith("-fp8hybrid"))
+if len(hybrids) != 1:
+    sys.exit(f"!! expected exactly one -fp8hybrid snapshot, found: {hybrids}")
+HYBRID = f"{REPO}/snapshots/{hybrids[0]}"
+GRAFT = HYBRID + "-mtpnvfp4"
+DONOR_BLOB = f"{DONOR}/blobs/{DONOR_SHA}"
+DONOR_SHARD = "nvfp4_experts_mtp.safetensors"
+FUSED = ("mtp.layers.0.mlp.experts.down_proj", "mtp.layers.0.mlp.experts.gate_up_proj")
+
+def read_header(path):
+    with open(path, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        return json.loads(f.read(n)), 8 + n
+
+# --- 1. the donor blob: download once, pinned revision + sha256 ------------
+os.makedirs(f"{DONOR}/blobs", exist_ok=True)
+os.makedirs(f"{DONOR}/snapshots/{DONOR_REV}", exist_ok=True)
+open(f"{DONOR}/refs/main", "w").write(DONOR_REV)
+if not os.path.exists(DONOR_BLOB):
+    url = f"https://huggingface.co/Inferact/Qwen3.8-Flash-Next-NVFP4/resolve/{DONOR_REV}/{DONOR_SHARD}"
+    print(">> downloading donor shard (~1.5 GiB)")
+    tmp = DONOR_BLOB + ".incomplete"
+    h = hashlib.sha256()
+    with urllib.request.urlopen(urllib.request.Request(url), timeout=300) as r, open(tmp, "wb") as f:
+        while True:
+            chunk = r.read(1 << 22)
+            if not chunk:
+                break
+            h.update(chunk)
+            f.write(chunk)
+    got = h.hexdigest()
+    if got != DONOR_SHA:
+        os.remove(tmp)
+        sys.exit(f"!! donor sha256 mismatch: got {got}, want {DONOR_SHA}")
+    os.rename(tmp, DONOR_BLOB)
+link = f"{DONOR}/snapshots/{DONOR_REV}/{DONOR_SHARD}"
+if not os.path.lexists(link):
+    os.symlink(f"../../blobs/{DONOR_SHA}", link)
+
+# --- 2. donor sanity: a clean, quantized draft-head shard ------------------
+dhdr, _ = read_header(DONOR_BLOB)
+dhdr.pop("__metadata__", None)
+stray = [k for k in dhdr if not k.startswith("mtp.")]
+if stray:
+    sys.exit(f"!! donor shard holds {len(stray)} tensors outside mtp. (e.g. {stray[0]}) — refusing")
+experts = sorted(k for k in dhdr if re.match(r"mtp\.layers\.0\.mlp\.experts\.\d+\.", k))
+shared = sorted(k for k in dhdr if k not in set(experts))
+print(f">> donor: {len(experts)} NVFP4 expert tensors + {len(shared)} shared (full-width)")
+if len(experts) != 6144 or len(shared) != 29:
+    sys.exit(f"!! unexpected donor layout: {len(experts)} experts / {len(shared)} shared")
+if any(k in dhdr for k in FUSED):
+    sys.exit("!! donor unexpectedly contains fused expert tensors")
+bad = [k for k in experts
+       if k.endswith(".weight")
+       and (dhdr[k]["dtype"] != "U8" or k.removesuffix(".weight") + ".weight_scale" not in dhdr)]
+if bad:
+    sys.exit(f"!! donor expert tensors without U8 dtype or a weight_scale sibling: {bad[:3]}")
+fullwidth = [k for k in shared if dhdr[k]["dtype"] not in ("BF16", "F16", "F32")]
+if fullwidth:
+    sys.exit(f"!! shared donor tensors not full-width: {fullwidth[:3]}")
+# the 29 non-expert MTP modules that stay full-width once "mtp.*" is gone
+additions = sorted({k.removesuffix(".weight") for k in shared})
+for need in ("mtp.fc_embedding", "mtp.fc_hidden"):
+    if need not in additions:
+        sys.exit(f"!! {need} missing from the donor's shared tensors — the exclude fix would be wrong")
+
+# --- 3. lay out the graft snapshot as relative symlinks --------------------
+os.makedirs(GRAFT, exist_ok=True)
+SKIP = ("model.safetensors.index.json", "config.json", "hf_quant_config.json",
+        "model-bf16-00011.safetensors", DONOR_SHARD, ".prepared", "fp8_convert.log")
+linked = 0
+for name in sorted(os.listdir(HYBRID)):
+    if name in SKIP:
+        continue
+    dst = os.path.join(GRAFT, name)
+    if os.path.lexists(dst):
+        os.remove(dst)
+    os.symlink(f"../{hybrids[0]}/{name}", dst)
+    linked += 1
+dst = os.path.join(GRAFT, DONOR_SHARD)
+if os.path.lexists(dst):
+    os.remove(dst)
+os.symlink(f"../../../models--Inferact--Qwen3.8-Flash-Next-NVFP4/blobs/{DONOR_SHA}", dst)
+print(f">> linked {linked} files from the hybrid snapshot + the donor shard")
+
+# --- 4. rewrite the contaminated shard (hybrid's real 00011 minus the fused)
+import torch
+from safetensors.torch import load_file, save_file
+tensors = load_file(f"{HYBRID}/model-bf16-00011.safetensors")
+dropped = [k for k in FUSED if k in tensors]
+if sorted(dropped) != sorted(FUSED):
+    sys.exit(f"!! expected the 2 fused MTP expert tensors in the hybrid shard, found {dropped}")
+for k in FUSED:
+    del tensors[k]
+out = f"{GRAFT}/model-bf16-00011.safetensors"
+save_file(tensors, out, metadata={"format": "pt"})
+size = os.path.getsize(out) / 2**30
+del tensors
+print(f">> rewrote model-bf16-00011.safetensors minus {len(dropped)} fused tensors ({size:.2f} GiB)")
+
+# --- 5. rewrite the index --------------------------------------------------
+index = json.load(open(f"{HYBRID}/model.safetensors.index.json"))
+wm = index["weight_map"]
+removed = [k for k in FUSED if k in wm]
+for k in removed:
+    del wm[k]
+for k in experts:
+    wm[k] = DONOR_SHARD
+json.dump(index, open(f"{GRAFT}/model.safetensors.index.json", "w"))
+print(f">> index: removed {len(removed)} fused keys, added {len(experts)} NVFP4 expert keys "
+      f"({len(wm)} entries)")
+
+# --- 6. fix BOTH exclude lists, identically --------------------------------
+def fix(entries, source):
+    kept = [p for p in entries if p not in ("mtp.*", "model.mtp.*")]
+    dropped = [p for p in entries if p not in kept]
+    if len(dropped) != 2:
+        sys.exit(f"!! {source}: expected the 2 blanket mtp globs, found {dropped}")
+    clash = [p for p in kept if p.startswith("mtp.") or p == "model.mtp"]
+    if clash:
+        sys.exit(f"!! {source}: explicit mtp entries already present: {clash}")
+    return kept + additions, dropped
+
+cfg = json.load(open(f"{HYBRID}/config.json"))       # read via symlink, write real
+field = next((f for f in ("ignore", "exclude_modules")
+              if isinstance(cfg.get("quantization_config", {}).get(f), list)), None)
+if field is None:
+    sys.exit("!! no ignore/exclude_modules list in config.json quantization_config")
+cfg["quantization_config"][field], dropped_cfg = fix(cfg["quantization_config"][field], "config.json")
+json.dump(cfg, open(f"{GRAFT}/config.json", "w"))
+
+hqc = json.load(open(f"{HYBRID}/hf_quant_config.json"))
+hqc["quantization"]["exclude_modules"], dropped_hqc = fix(hqc["quantization"]["exclude_modules"], "hf_quant_config.json")
+json.dump(hqc, open(f"{GRAFT}/hf_quant_config.json", "w"))
+print(f">> {field} and exclude_modules: dropped {dropped_cfg}, added {len(additions)} explicit "
+      f"MTP module names (13 -> {len(cfg['quantization_config'][field])} entries)")
+
+# --- 7. static verification (gate the .prepared marker on it) --------------
+errors = []
+for name in sorted(os.listdir(GRAFT)):
+    p = os.path.join(GRAFT, name)
+    if os.path.islink(p) and not os.path.exists(p):
+        errors.append(f"dangling symlink: {name}")
+
+index = json.load(open(f"{GRAFT}/model.safetensors.index.json"))
+wm = index["weight_map"]
+by_file = {}
+for k, f in wm.items():
+    by_file.setdefault(f, []).append(k)
+donor_keys = set()
+for fname, keys in by_file.items():
+    path = os.path.join(GRAFT, fname)
+    if not os.path.exists(path):
+        errors.append(f"index references missing file: {fname}")
+        continue
+    hdr, _ = read_header(path)
+    hdr.pop("__metadata__", None)
+    for k in keys:
+        if k not in hdr:
+            errors.append(f"index key absent from shard: {k} -> {fname}")
+    stray_fused = [k for k in FUSED if k in hdr]
+    if stray_fused:
+        errors.append(f"fused MTP tensors still in {fname}: {stray_fused}")
+    if fname == DONOR_SHARD:
+        donor_keys = set(keys)
+
+if len(donor_keys) != 6144:
+    errors.append(f"expected 6144 donor keys in the index, got {len(donor_keys)}")
+gcfg = json.load(open(f"{GRAFT}/config.json"))
+ghqc = json.load(open(f"{GRAFT}/hf_quant_config.json"))
+ig = gcfg["quantization_config"][field]
+em = ghqc["quantization"]["exclude_modules"]
+if ig != em:
+    errors.append("config.json and hf_quant_config.json exclude lists disagree")
+if any(p in ig for p in ("mtp.*", "model.mtp.*")):
+    errors.append("blanket mtp glob still present in the graft configs")
+if len(ig) != 40:
+    errors.append(f"expected 40 exclude entries after the fix, got {len(ig)}")
+for need in ("mtp.fc_embedding", "mtp.fc_hidden"):
+    if need not in ig:
+        errors.append(f"{need} not in the graft exclude list — the draft fc linears would be quantized")
+if gcfg.get("text_config", {}).get("ple_embedding_dtype") != "float8_e4m3fn":
+    errors.append("ple_embedding_dtype is no longer float8_e4m3fn")
+if errors:
+    for e in errors:
+        print(f"   !! {e}")
+    sys.exit(f"!! static verification failed ({len(errors)} problems) — graft NOT marked prepared")
+
+os.chmod(out, 0o644)
+for j in ("model.safetensors.index.json", "config.json", "hf_quant_config.json"):
+    os.chmod(f"{GRAFT}/{j}", 0o644)
+open(f"{GRAFT}/.prepared", "w").close()
+print(f">> static verification passed — graft ready: {GRAFT}")
+PYEOF
+[ -f "$REPO_DIR/snapshots/$GRAFT_NAME/.prepared" ] || {
+  echo "!! graft script finished without a .prepared marker — static verification failed?"; exit 1; }
+
+echo ">> graft checkpoint ready. Serve with:  MODE=hybrid-mtp scripts/serve.sh"

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -4,6 +4,7 @@
 #
 #   scripts/serve.sh                          # NVFP4 checkpoint as published, 262k ctx
 #   MODE=hybrid scripts/serve.sh              # NVFP4 experts + fp8 side layers (scripts/prepare-hybrid.sh first)
+#   MODE=hybrid-mtp scripts/serve.sh          # hybrid + NVFP4 MTP draft experts (scripts/prepare-mtp-graft.sh first)
 #   YARN=1 CTX=500000 scripts/serve.sh        # 500k context via YaRN (validated)
 #   docker logs -f qwen38-flash               # wait for "Application startup complete"
 #
@@ -11,6 +12,9 @@
 #   MODE=nvfp4        nvfp4 = the checkpoint as published (side layers bf16)
 #                     hybrid = side layers in blockwise fp8: +20% decode, +15-20% KV, same
 #                     tournament score. Needs the one-time scripts/prepare-hybrid.sh
+#                     hybrid-mtp = hybrid with the MTP draft experts in NVFP4 (grafted from
+#                     Inferact's checkpoint): ~3.4 GB less on the card, ~4x fewer bytes read
+#                     per draft step. Needs scripts/prepare-mtp-graft.sh
 #   PREFIX_CACHE=1    1 = --enable-prefix-caching (correct with this image's block_size fix;
 #                     repeated prefixes — system prompts, multi-turn, tool loops — skip the prefill)
 #   DET_TOPK=1        1 = deterministic QSA top-k KERNEL (@jschmied, vllm#55122): identical output at
@@ -71,15 +75,18 @@ SNAP_NAME="$(basename "$SNAP_HOST")"
 HYBRID_ENV=()
 case "$MODE" in
   nvfp4) ;;
-  hybrid)
-    if [ ! -f "$REPO_DIR/snapshots/${SNAP_NAME}-fp8hybrid/.prepared" ]; then
-      echo "!! hybrid checkpoint not prepared: run scripts/prepare-hybrid.sh first (one-time, ~10 min)"
+  hybrid|hybrid-mtp)
+    SUFFIX="-fp8hybrid"
+    [ "$MODE" = hybrid-mtp ] && SUFFIX="-fp8hybrid-mtpnvfp4"
+    if [ ! -f "$REPO_DIR/snapshots/${SNAP_NAME}${SUFFIX}/.prepared" ]; then
+      [ "$MODE" = hybrid ] && echo "!! hybrid checkpoint not prepared: run scripts/prepare-hybrid.sh first (one-time, ~10 min)" \
+        || echo "!! hybrid-mtp checkpoint not prepared: run scripts/prepare-mtp-graft.sh first (needs prepare-hybrid.sh; one-time, ~5 min)"
       exit 1
     fi
-    SNAP_NAME="${SNAP_NAME}-fp8hybrid"
+    SNAP_NAME="${SNAP_NAME}${SUFFIX}"
     HYBRID_ENV=(-e VLLM_FP8_HYBRID=1 -e VLLM_USE_DEEP_GEMM=0)
     ;;
-  *) echo "!! MODE must be nvfp4 or hybrid"; exit 1 ;;
+  *) echo "!! MODE must be nvfp4, hybrid or hybrid-mtp"; exit 1 ;;
 esac
 SNAP_IN="/hf/hub/models--${MODEL//\//--}/snapshots/$SNAP_NAME"
 


### PR DESCRIPTION
## hybrid-mtp: NVFP4 MTP draft experts grafted onto the hybrid checkpoint

**Branch:** `mtp-nvfp4-graft` · **New:** `scripts/prepare-mtp-graft.sh`, `scripts/greedy-probe.sh` · **New mode:** `MODE=hybrid-mtp`

### What this does

Combines the two things every public NVFP4 checkpoint gets half-right:

| checkpoint | PLE table | MTP draft experts |
|---|---|---|
| `RadixArk/Qwen3.8-Flash-Next-NVFP4` (this repo's base) | **fp8** (small) | BF16 fused (expensive) |
| `Inferact/Qwen3.8-Flash-Next-NVFP4` | BF16 (huge) | **NVFP4** (cheap) |
| **this graft (`MODE=hybrid-mtp`)** | **fp8** | **NVFP4** |

The MTP draft head's routed experts (fused BF16, ~4.7 GiB) are replaced by the per-expert
NVFP4 donor block (1.4 GiB) from Inferact's checkpoint of the same base. No retraining, no
requantization — a byte-level graft built on top of the existing `-fp8hybrid` snapshot.
Recipe follows [thavoc's graft write-up](https://gist.github.com/thavoc/d7083457f6f2d981f879670c34df34ab)
and [Peuqui/mtp-quant-transplant](https://github.com/Peuqui/mtp-quant-transplant).

### Mechanics

- `model-bf16-00011.safetensors` rewritten **without** the 2 fused BF16 MTP tensors
  (`mtp.layers.0.mlp.experts.{down_proj,gate_up_proj}`). Physically removed, not just
  dropped from the index: the weight iterator walks whole files, so stray fused tensors
  would still reach `RoutedExperts.load_weights` and crash against the NVFP4 params.
- +6,144 NVFP4 per-expert tensors via a relative symlink to the donor shard
  (`nvfp4_experts_mtp.safetensors`, pinned rev `103a7608`, sha256-verified); index
  296,775 → 302,917 entries.
- **Both** quantization exclusion lists fixed — `config.json`
  (`quantization_config.ignore`) *and* `hf_quant_config.json`
  (`quantization.exclude_modules`): the blanket `mtp.*` / `model.mtp.*` globs are replaced
  by the donor's **29 explicit non-expert MTP module names** (13 → 40 entries). Fixing
  only one leaves the draft unquantized (load dies on missing `w2_input_scale` / shape
  asserts); deleting the globs outright quantizes the draft's attention, shared expert and
  `fc_*` linears, whose tensors are BF16 (`mtp.fc_embedding` / `mtp.fc_hidden` are not
  covered by any remaining pattern).
- The engine side already supports both layouts: `RoutedExperts.load_weights` builds its
  mapping with `include_fused=True` and dispatches per tensor on rank, and the draft's
  quant config is resolved from the checkpoint's own quant JSONs with vLLM's
  `mtp.layers.0` → `mtp.layers.48` renumbering. No engine patch needed — verified
  in-container before building.

### Why it is safe

- **Same base, verified**: `embed_tokens.weight` and all 29 shared draft tensors hash
  identical (sha256) across the two parents before grafting.
- **The target model is untouched**: its loader skips everything under `mtp.`
  (`skip_substrs=["mtp."]`); the fp8-hybrid dispatch still detects exactly the same 300
  side layers.
- **Gated on greedy output equivalence**: every emitted token is the target model's argmax
  (the draft only changes per-step acceptance), so a draft swap must not change text.
  `scripts/greedy-probe.sh` run against the BF16-MTP arm and the graft produces
  **byte-identical output — 5/5 prompts, 400 tokens each, first-token logprobs identical
  to 4 decimals**.

### Measured (GX10, GB10 128 GB, TP=1, MTP=2, greedy, default envs)

| | `MODE=hybrid` | `MODE=hybrid-mtp` |
|---|---|---|
| Weights on card | 77.83 GiB | **74.75 GiB** (−3.1) |
| KV pool @ `GPU_MEM=0.80` | 625,669 tok | **734,292 tok (+17%)** |
| Max concurrency @ 262k ctx | 2.39x | **2.80x** |
| Greedy decode, 5-prompt probe | 26.6–33.8 tok/s | **34.7–42.5 tok/s (+20–27%)** |
| Mean acceptance length | ~2.73 | ~2.58 (same band) |

The draft swap is pure win here: same fixed-shape verification cost, ~4x fewer bytes read
per draft step, ~3 GiB back to KV. Disk cost: ~3.3 GB of real bytes (one rewritten shard).

### Try it

```bash
scripts/prepare-hybrid.sh          # if not already done
scripts/prepare-mtp-graft.sh       # ~5 min incl. the 1.5 GiB donor download (one-time)
MODE=hybrid-mtp scripts/serve.sh
scripts/smoke-test.sh              # and scripts/greedy-probe.sh to re-run the gate
```

### Caveats

- The graft directory is symlinks into **both** parent snapshots plus the Inferact blob —
  HF cache tooling cannot see that; do not prune either parent.
- Donor revision is pinned (`103a7608`, sha256 `0d44e6d7…`); a different donor needs
  re-gating (byte-equality check + greedy probe).
- Pre-existing, unrelated: the smoke-test's cold-vs-hit determinism check fails the same
  way on the plain `MODE=hybrid` arm on the current image (verified in this PR's A/B) —
  the graft behaves identically to the baseline there.

### References / credits

- Graft method: [thavoc's write-up](https://gist.github.com/thavoc/d7083457f6f2d981f879670c34df34ab), [Peuqui/mtp-quant-transplant](https://github.com/Peuqui/mtp-quant-transplant)
- Donor block: [Inferact/Qwen3.8-Flash-Next-NVFP4](https://huggingface.co/Inferact/Qwen3.8-Flash-Next-NVFP4)