### PR TITLE
v0.29: preserve tool prose and add opt-in reasoning EOS guard

### DIFF
--- a/Dockerfile.v0.29
+++ b/Dockerfile.v0.29
@@ -66,3 +66,14 @@ RUN cd /opt/llm/kernel-det/src && DET_BUILD_DIR=/opt/llm/kernel-det/build DET_AR
 COPY src/patch_mtp_draft_vocab.py /tmp/patch_mtp_draft_vocab.py
 COPY src/draft_vocab_65536.npy /opt/llm/draft_vocab_65536.npy
 RUN python3 /tmp/patch_mtp_draft_vocab.py ${PKG}/mtp.py && rm /tmp/patch_mtp_draft_vocab.py
+
+
+# --- 11. Lossless Qwen tool preambles + optional reasoning EOS guard ---
+# Covers both Model Runner V1 and the v0.29 default V2 sampler. The guard is
+# enabled only by --reasoning-config.suppress_eos_in_reasoning=true.
+COPY src/patches/v029-qwen-tool-preamble.patch /tmp/qwen-tool-preamble.patch
+COPY src/patches/v029-reasoning-eos.patch /tmp/qwen-reasoning-eos.patch
+RUN cd ${SP} \
+ && patch --batch --forward --fuzz=0 -p1 < /tmp/qwen-tool-preamble.patch \
+ && patch --batch --forward --fuzz=0 -p1 < /tmp/qwen-reasoning-eos.patch \
+ && rm /tmp/qwen-tool-preamble.patch /tmp/qwen-reasoning-eos.patch

--- a/README.md
+++ b/README.md
@@ -566,10 +566,11 @@ original reasoning/content channel. Whitespace followed by a valid `<function=`
 header continues to start a tool call. A malformed opener does not disable the
 EOS guard.
 
-This changes generation only when EOS would otherwise end an open reasoning
-section, so answer quality still needs workload evaluation. EOS in final-answer
-text remains a protocol terminator: this option does not make literal special
-tokens safe to quote everywhere. The preview image does not carry these patches.
+While reasoning is open, removing EOS changes the sampling distribution and can
+change the generated tokens; answer quality still needs workload evaluation.
+EOS in final-answer text remains a protocol terminator: this option does not
+make literal special tokens safe to quote everywhere. The preview image does
+not carry these patches.
 
 The regression patch in `src/patches/v029-reasoning-regressions.patch` applies to
 a vLLM `v0.29.0` source checkout. Apply the two runtime patches there as well and

--- a/README.md
+++ b/README.md
@@ -546,6 +546,37 @@ boot-to-boot range of the preview image). **The preview `Dockerfile` remains the
 field time on our own box; if you want to be on the release line, it is ready and tested.
 Full port notes in [docs/HOW-IT-WORKS.md](docs/HOW-IT-WORKS.md#the-vllm-v0290-port-dockerfilev029).
 
+### Reasoning EOS recovery and quoted tool markers (v0.29 image)
+
+An EOS token sampled while Qwen is still reasoning can produce a successful HTTP
+response with no answer. The v0.29 image includes an opt-in sampler guard:
+
+```bash
+IMAGE=qwen38-flash-dgx:v0.29 REASONING_EOS_GUARD=1 scripts/serve.sh
+```
+
+The guard masks the model's EOS IDs while a reasoning section is open. It does
+not force `</think>`, insert an answer, or set a thinking budget. Natural reasoning
+endings and valid direct tool transitions restore normal EOS handling. Explicit
+`ignore_eos` and output limits keep their usual meaning. Both model runners and
+MTP verification use the guard; rejected draft tokens never advance its state.
+
+A quoted malformed `<tool_call>` followed by prose is also preserved in its
+original reasoning/content channel. Whitespace followed by a valid `<function=`
+header continues to start a tool call. A malformed opener does not disable the
+EOS guard.
+
+This changes generation only when EOS would otherwise end an open reasoning
+section, so answer quality still needs workload evaluation. EOS in final-answer
+text remains a protocol terminator: this option does not make literal special
+tokens safe to quote everywhere. The preview image does not carry these patches.
+
+The regression patch in `src/patches/v029-reasoning-regressions.patch` applies to
+a vLLM `v0.29.0` source checkout. Apply the two runtime patches there as well and
+run the existing parser engine, thinking-budget state, and GPU thinking-budget
+suites. The GPU suite includes MTP 2/3/4, rejected drafts, reused request slots,
+multi-token markers, and a prompt near the native context boundary.
+
 ## Tuning (env vars for `scripts/serve.sh`)
 
 | Var | Default | Notes |
@@ -562,6 +593,7 @@ Full port notes in [docs/HOW-IT-WORKS.md](docs/HOW-IT-WORKS.md#the-vllm-v0290-po
 | `YARN` | `0` | `1` = YaRN rope scaling (factor 4, Qwen's recipe) for `CTX` > 262144. |
 | `SEQS` | `8` | Max concurrent sequences. **Do not benchmark with 1–2**: excess requests queue silently and aggregate tok/s flatlines (see below). |
 | `GPU_MEM` | `0.80` | Fraction of the 128 GB pool for weights+KV. `0.85` buys ~2 GiB more KV, but after a day at `0.85` the box drifted into swap, and `0.875` got OOM-killed on a 300k-token prefill with MTP. The lower you set it, the more RAM the page cache has for the 48 GiB table — which is what your prefill speed depends on (below). Right after stopping another big container the first boot can fail with "13.5 GiB KV cache is needed, larger than available" — memory not yet released; the `unless-stopped` retry succeeds. |
+| `REASONING_EOS_GUARD` | `0` | v0.29 only: suppress EOS while reasoning is open, without forcing it to end. |
 | `MTP` | `2` | Speculative tokens from the model's MTP head (`0` = off). `3` is +7% decode but cost a point at the tournament (44 vs 45/51), so it stays an option. |
 | `KV_DTYPE` | `auto` | `auto` = bf16 (recommended). `fp8_e4m3` = ~1.9× KV pool, 1M context on one box, at −10% decode / −30% prefill and a measurable quality cost — see [fp8 KV cache](docs/HOW-IT-WORKS.md#fp8-kv-cache-on-the-qsa-path-opt-in) before using it. |
 | `PREWARM` | `0` | `1` streams the 48 GiB table once at boot to warm the page cache — steadier first-request latency, ~10 s extra startup. |

--- a/README.md
+++ b/README.md
@@ -568,6 +568,8 @@ EOS guard.
 
 While reasoning is open, removing EOS changes the sampling distribution and can
 change the generated tokens; answer quality still needs workload evaluation.
+Reasoning can still exhaust the requested output budget without producing a
+final answer.
 EOS in final-answer text remains a protocol terminator: this option does not
 make literal special tokens safe to quote everywhere. The preview image does
 not carry these patches.

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -56,6 +56,7 @@ PAD_M4="${PAD_M4:-0}"
 DRAFT_VOCAB="${DRAFT_VOCAB:-1}"
 MADVISE="${MADVISE:-random}"
 LOG_REQUESTS="${LOG_REQUESTS:-0}"
+REASONING_EOS_GUARD="${REASONING_EOS_GUARD:-0}"
 PORT="${PORT:-18300}"
 CTX="${CTX:-262144}"
 YARN="${YARN:-0}"
@@ -119,6 +120,13 @@ if [ "$BASE" = "v0.29" ]; then
   fi
   [ "$PAD_M4" != 0 ] && echo "!! PAD_M4 has no effect on the v0.29 base (vllm#52775 fixed the fp8 GEMM there); ignoring" && PAD_M4=0
 fi
+REASONING_ARGS=()
+if [ "$REASONING_EOS_GUARD" = 1 ]; then
+  if [ "$BASE" != "v0.29" ]; then
+    echo "!! REASONING_EOS_GUARD requires the v0.29 image" >&2; exit 1
+  fi
+  REASONING_ARGS=(--reasoning-config '{"suppress_eos_in_reasoning":true}')
+fi
 CC="${CC:--cc.cudagraph_mode=PIECEWISE -cc.splitting_ops=$SPLIT}"
 
 # YaRN (Qwen's published recipe) to go past the native 262144.
@@ -171,7 +179,7 @@ docker run -d --name "$NAME" --restart unless-stopped \
     --no-enable-flashinfer-autotune \
     --kv-cache-dtype "$KV_DTYPE" \
     "${OVR_ARGS[@]}" "${LOGARGS[@]}" $EXTRA \
-    --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3 \
+    --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3 ${REASONING_ARGS[@]+"${REASONING_ARGS[@]}"} \
     "${SPEC[@]}"
 
 # Fail loudly instead of printing a success line over a dead container: give vLLM a few

--- a/src/patches/v029-qwen-tool-preamble.patch
+++ b/src/patches/v029-qwen-tool-preamble.patch
@@ -1,0 +1,165 @@
+diff --git a/vllm/parser/engine/parser_engine_config.py b/vllm/parser/engine/parser_engine_config.py
+index 4799604..164aa55 100644
+--- a/vllm/parser/engine/parser_engine_config.py
++++ b/vllm/parser/engine/parser_engine_config.py
+@@ -100,6 +100,9 @@ class ParserEngineConfig:
+     # Reject tool calls whose names are absent from the request tools.
+     validate_tool_names: bool = False
+ 
++    # Delay a tool wrapper until its whitespace-only preamble reaches TOOL_NAME.
++    validate_tool_preamble: bool = False
++
+     @cached_property
+     def terminal_defs(self):
+         from vllm.parser.engine.incremental_lexer import terminals_from_literals
+diff --git a/vllm/parser/engine/streaming_parser_engine.py b/vllm/parser/engine/streaming_parser_engine.py
+index ec21b05..d42f57e 100644
+--- a/vllm/parser/engine/streaming_parser_engine.py
++++ b/vllm/parser/engine/streaming_parser_engine.py
+@@ -207,6 +207,9 @@ class StreamingParserEngine:
+         self._message_header_buffer = ""
+         self._message_header_token_count = 0
+         self._in_skipped_tool_span = False
++        self._pending_tool_start: tuple[str, str, int] | None = None
++        self._tool_preamble_buffer = ""
++        self._tool_preamble_token_count = 0
+         self._reset_args_state()
+ 
+     def feed(
+@@ -284,6 +287,8 @@ class StreamingParserEngine:
+ 
+         events.extend(self._process_lex_tokens(self._lexer.flush()))
+ 
++        events.extend(self._confirm_tool_preamble())
++
+         if self._args_buffer:
+             events.append(
+                 SemanticEvent(
+@@ -359,8 +364,28 @@ class StreamingParserEngine:
+     )
+ 
+     def _on_terminal(
+-        self, terminal: str, value: str, token_count: int = 0
++        self,
++        terminal: str,
++        value: str,
++        token_count: int = 0,
++        *,
++        confirmed_tool_start: bool = False,
+     ) -> list[SemanticEvent]:
++        if self._pending_tool_start is not None:
++            next_transition = self.config.transitions.get(
++                (ParserState.TOOL_PREAMBLE, terminal)
++            )
++            if next_transition is not None and next_transition.next_state in (
++                ParserState.TOOL_NAME,
++                ParserState.CONTENT,
++            ):
++                events = self._confirm_tool_preamble()
++                events.extend(self._on_terminal(terminal, value, token_count))
++                return events
++            events = self._flush_tool_preamble()
++            events.extend(self._on_terminal(terminal, value, token_count))
++            return events
++
+         key = (self.state, terminal)
+         transition = self.config.transitions.get(key)
+ 
+@@ -372,6 +397,15 @@ class StreamingParserEngine:
+                 self._in_skipped_tool_span = False
+             return self._emit_for_state(value, token_count)
+ 
++        if (
++            self.config.validate_tool_preamble
++            and not confirmed_tool_start
++            and self.state in (ParserState.CONTENT, ParserState.REASONING)
++            and transition.next_state == ParserState.TOOL_PREAMBLE
++        ):
++            self._pending_tool_start = (terminal, value, token_count)
++            return []
++
+         if self.skip_tool_parsing and terminal in self._tool_terminals:
+             # Inkling reuses one terminal for tool, text, and reasoning exits.
+             # Outside a forwarded tool span, apply its normal transition.
+@@ -430,6 +464,26 @@ class StreamingParserEngine:
+         return self._apply_transition(transition, value, token_count)
+ 
+     def _emit_for_state(self, text: str, token_count: int = 0) -> list[SemanticEvent]:
++        if self._pending_tool_start is not None:
++            self._tool_preamble_buffer += text
++            self._tool_preamble_token_count += token_count
++            if text.strip():
++                candidate = self._tool_preamble_buffer.lstrip()
++                for (state, terminal), tr in self.config.transitions.items():
++                    if (
++                        state == ParserState.TOOL_PREAMBLE
++                        and tr.next_state == ParserState.TOOL_NAME
++                        and (literal := self.config.terminals.get(terminal))
++                        and any(
++                            value.startswith(candidate)
++                            for value in (
++                                (literal,) if isinstance(literal, str) else literal
++                            )
++                        )
++                    ):
++                        return []
++                return self._flush_tool_preamble()
++            return []
+         if self.state == ParserState.MESSAGE_HEADER:
+             self._message_header_buffer += text
+             self._message_header_token_count += token_count
+@@ -457,6 +511,30 @@ class StreamingParserEngine:
+             ]
+         return []
+ 
++    def _flush_tool_preamble(self) -> list[SemanticEvent]:
++        if self._pending_tool_start is None:
++            return []
++        _, opener, opener_count = self._pending_tool_start
++        text = opener + self._tool_preamble_buffer
++        count = opener_count + self._tool_preamble_token_count
++        self._pending_tool_start = None
++        self._tool_preamble_buffer = ""
++        self._tool_preamble_token_count = 0
++        return self._emit_for_state(text, count)
++
++    def _confirm_tool_preamble(self) -> list[SemanticEvent]:
++        if self._pending_tool_start is None:
++            return []
++        opener = self._pending_tool_start
++        text = self._tool_preamble_buffer
++        count = self._tool_preamble_token_count
++        self._pending_tool_start = None
++        self._tool_preamble_buffer = ""
++        self._tool_preamble_token_count = 0
++        events = self._on_terminal(*opener, confirmed_tool_start=True)
++        events.extend(self._emit_for_state(text, count))
++        return events
++
+     def _on_content(self, text: str, token_count: int = 0) -> list[SemanticEvent]:
+         if not text:
+             return []
+diff --git a/vllm/parser/nemotron_v3.py b/vllm/parser/nemotron_v3.py
+index c8b75a2..2141c98 100644
+--- a/vllm/parser/nemotron_v3.py
++++ b/vllm/parser/nemotron_v3.py
+@@ -35,6 +35,7 @@ def nemotron_v3_config(thinking: bool = True) -> ParserEngineConfig:
+     return dataclasses.replace(
+         qwen3_config(thinking=thinking, turn_boundary_tokens=CHATML_TURN_BOUNDARIES),
+         name="nemotron_v3",
++        validate_tool_preamble=False,
+         strip_trailing_reasoning_whitespace=True,
+     )
+ 
+diff --git a/vllm/parser/qwen3.py b/vllm/parser/qwen3.py
+index 8edf42e..fd40925 100644
+--- a/vllm/parser/qwen3.py
++++ b/vllm/parser/qwen3.py
+@@ -198,6 +198,7 @@ def qwen3_config(
+         stream_arg_deltas=True,
+         strip_trailing_reasoning_whitespace=False,
+         tool_args_json=False,
++        validate_tool_preamble=name == "qwen3",
+     )
+ 
+ 

--- a/src/patches/v029-reasoning-eos.patch
+++ b/src/patches/v029-reasoning-eos.patch
@@ -1,0 +1,611 @@
+diff --git a/vllm/config/reasoning.py b/vllm/config/reasoning.py
+index 0ac93be..dfd9b89 100644
+--- a/vllm/config/reasoning.py
++++ b/vllm/config/reasoning.py
+@@ -25,6 +25,22 @@ class ReasoningConfig:
+     """String that indicates the start of reasoning."""
+     reasoning_end_str: str = ""
+     """String forced when the thinking budget is exhausted."""
++    suppress_eos_in_reasoning: bool = False
++    """Suppress model EOS tokens while reasoning is open, without forcing an end.
++
++    Opt-in recovery for premature EOS. The request's output limit still applies.
++    """
++
++    _eos_token_ids: list[int] = field(default_factory=list, init=False, repr=False)
++    """Model EOS IDs suppressed while the guard is active."""
++    _tool_start_token_id: int | None = field(default=None, init=False, repr=False)
++    """Qwen tool opener whose function header must be validated."""
++    _tool_end_token_id: int | None = field(default=None, init=False, repr=False)
++    """Qwen tool closer; also closes an empty wrapper."""
++    _tool_preamble_token_texts: dict[int, str] = field(
++        default_factory=dict, init=False, repr=False
++    )
++    """Token text needed to recognize a Qwen function header after a tool opener."""
+ 
+     _reasoning_start_token_ids: list[int] | None = field(
+         default=None, init=False, repr=False
+@@ -77,6 +93,26 @@ class ReasoningConfig:
+             return  # Already initialized
+ 
+         tokenizer = cached_tokenizer_from_config(model_config=model_config)
++        if self.suppress_eos_in_reasoning:
++            eos_ids = model_config.try_get_generation_config().get("eos_token_id", [])
++            if isinstance(eos_ids, int):
++                eos_ids = [eos_ids]
++            self._eos_token_ids = list(eos_ids or [])
++            if tokenizer.eos_token_id is not None:
++                self._eos_token_ids.append(tokenizer.eos_token_id)
++            self._eos_token_ids = sorted(set(self._eos_token_ids))
++            if self.reasoning_parser == "qwen3":
++                vocab = tokenizer.get_vocab()
++                self._tool_start_token_id = vocab.get("<tool_call>")
++                self._tool_end_token_id = vocab.get("</tool_call>")
++                if self._tool_start_token_id is not None:
++                    prefix = "<function="
++                    suffixes = tuple(prefix[i:] for i in range(len(prefix)))
++                    for token_id in vocab.values():
++                        text = tokenizer.decode([token_id], skip_special_tokens=False)
++                        part = text.lstrip()
++                        if not part or part in prefix or part.startswith(suffixes):
++                            self._tool_preamble_token_texts[token_id] = text
+         reasoning_start_str = self.reasoning_start_str
+         reasoning_end_str = self.reasoning_end_str
+         natural_reasoning_end_str = ""
+@@ -98,6 +134,10 @@ class ReasoningConfig:
+             natural_reasoning_end_str = reasoning_end_str
+ 
+         if not reasoning_start_str or not reasoning_end_str:
++            if self.suppress_eos_in_reasoning:
++                raise ValueError(
++                    "suppress_eos_in_reasoning requires reasoning start/end markers"
++                )
+             # If we don't have valid strings to tokenize,
+             # we can't initialize the token IDs.
+             return
+diff --git a/vllm/v1/sample/thinking_budget_state.py b/vllm/v1/sample/thinking_budget_state.py
+index 43880bf..ba9f02b 100644
+--- a/vllm/v1/sample/thinking_budget_state.py
++++ b/vllm/v1/sample/thinking_budget_state.py
+@@ -63,6 +63,19 @@ class ThinkingBudgetStateHolder:
+             self.think_end_token_ids = re if re else []
+ 
+         self.device = device
++        self.suppress_eos = bool(
++            getattr(reasoning_config, "suppress_eos_in_reasoning", False)
++        )
++        self.eos_token_ids = getattr(reasoning_config, "_eos_token_ids", [])
++        self.natural_end_ids = (
++            getattr(reasoning_config, "natural_reasoning_end_token_ids", None)
++            or self.think_end_token_ids
++        )
++        self.tool_start_id = getattr(reasoning_config, "_tool_start_token_id", None)
++        self.tool_end_id = getattr(reasoning_config, "_tool_end_token_id", None)
++        self.tool_preamble_texts = getattr(
++            reasoning_config, "_tool_preamble_token_texts", {}
++        )
+         self._state: dict[int, dict[str, Any]] = {}
+         self.cu_num_tokens: dict[int, int] = {}
+ 
+@@ -72,7 +85,7 @@ class ThinkingBudgetStateHolder:
+             self._mask_capacity = max_num_reqs
+ 
+     def has_tracked_requests(self) -> bool:
+-        """True when ``sync_batch`` has state for a ``thinking_token_budget`` row.
++        """True when a row needs thinking-budget or EOS-guard state.
+ 
+         Used to decide whether sampling needs output-token rows and spec combining;
+         distinct from merely having a holder instance (reasoning may be on with no
+@@ -89,12 +102,29 @@ class ThinkingBudgetStateHolder:
+ 
+         for index, params, prompt_tok_ids, output_tok_ids in batch_update.added:
+             thinking_token_budget = params.thinking_token_budget
+-            if thinking_token_budget is not None:
++            guard_enabled = self.suppress_eos and not params.ignore_eos
++            if thinking_token_budget is not None or guard_enabled:
+                 self._state[index] = self._init_state_entry(
+-                    prompt_tok_ids, thinking_token_budget
++                    prompt_tok_ids,
++                    thinking_token_budget if thinking_token_budget is not None else -1,
+                 )
+                 self._state[index]["output_tok_ids"] = output_tok_ids
+                 self._state[index]["spec_token_ids"] = []
++                guard_state = self._state[index]
++                guard_state["eos_guard_enabled"] = guard_enabled
++                guard_state["eos_guard_in_think"] = False
++                guard_state["eos_guard_tail"] = []
++                guard_state["eos_guard_preamble"] = None
++                guard_state["eos_guard_offset"] = 0
++                if guard_enabled:
++                    active, tail, preamble = self._advance_eos_guard(
++                        False, [], prompt_tok_ids or []
++                    )
++                    guard_state["eos_guard_in_think"] = active
++                    guard_state["eos_guard_tail"] = tail
++                    guard_state["eos_guard_preamble"] = preamble
++                    if thinking_token_budget is None:
++                        guard_state["in_end"] = False
+             else:
+                 self._state.pop(index, None)
+ 
+@@ -146,6 +176,18 @@ class ThinkingBudgetStateHolder:
+             state["in_spec_mode"] = self.in_spec_mode
+             state["force_index"] = []
+             self._update_think_state(state)
++            if state["eos_guard_enabled"]:
++                output_ids = state["output_tok_ids"]
++                active, tail, preamble = self._advance_eos_guard(
++                    state["eos_guard_in_think"],
++                    state["eos_guard_tail"],
++                    output_ids[state["eos_guard_offset"] :],
++                    state["eos_guard_preamble"],
++                )
++                state["eos_guard_in_think"] = active
++                state["eos_guard_tail"] = tail
++                state["eos_guard_preamble"] = preamble
++                state["eos_guard_offset"] = len(output_ids)
+ 
+     def apply_to_logits(
+         self,
+@@ -157,8 +199,92 @@ class ThinkingBudgetStateHolder:
+         if not self.is_enabled or not self._state:
+             return logits
+         spec_lists = spec_token_ids or []
++        if self.suppress_eos:
++            self._suppress_reasoning_eos(logits, predict_bonus_token, spec_lists)
+         return self._apply_forcing_to_logits(logits, predict_bonus_token, spec_lists)
+ 
++    def _advance_eos_guard(
++        self,
++        active: bool,
++        tail: list[int],
++        token_ids: list[int],
++        preamble: str | None = None,
++    ) -> tuple[bool, list[int], str | None]:
++        tail = list(tail)
++        width = max(len(self.think_start_token_ids), len(self.natural_end_ids), 1)
++        for token_id in token_ids:
++            tail.append(token_id)
++            tail = tail[-width:]
++            if self.think_start_token_ids and (
++                tail[-len(self.think_start_token_ids) :] == self.think_start_token_ids
++            ):
++                active = True
++                preamble = None
++            elif self.natural_end_ids and (
++                tail[-len(self.natural_end_ids) :] == self.natural_end_ids
++            ):
++                active = False
++                preamble = None
++            elif active and token_id == self.tool_start_id:
++                preamble = ""
++            elif active and preamble is not None:
++                if token_id == self.tool_end_id:
++                    active = False
++                    preamble = None
++                    continue
++                text = self.tool_preamble_texts.get(token_id)
++                if text is None:
++                    preamble = None
++                    continue
++                candidate = (preamble + text).lstrip()
++                if candidate.startswith("<function="):
++                    active = False
++                    preamble = None
++                elif "<function=".startswith(candidate):
++                    preamble = candidate
++                else:
++                    preamble = None
++        return active, tail, preamble
++
++    def _suppress_reasoning_eos(
++        self,
++        logits: torch.Tensor,
++        predict_bonus_token: bool,
++        spec_lists: list[list[int]],
++    ) -> None:
++        rows: list[int] = []
++        tokens: list[int] = []
++        offset = 0
++        n_reqs = max(len(spec_lists), max(self._state, default=-1) + 1)
++        for index in range(n_reqs):
++            draft = spec_lists[index] if index < len(spec_lists) else []
++            count = len(draft) if self.in_spec_mode and not predict_bonus_token else 1
++            state = self._state.get(index)
++            if state is not None and state["eos_guard_enabled"]:
++                active = state["eos_guard_in_think"]
++                tail = state["eos_guard_tail"]
++                preamble = state["eos_guard_preamble"]
++                if predict_bonus_token:
++                    active, tail, preamble = self._advance_eos_guard(
++                        active, tail, draft, preamble
++                    )
++                for position in range(count):
++                    if active and offset + position < logits.shape[0]:
++                        for token_id in self.eos_token_ids:
++                            rows.append(offset + position)
++                            tokens.append(token_id)
++                    if not predict_bonus_token and draft:
++                        active, tail, preamble = self._advance_eos_guard(
++                            active, tail, [draft[position]], preamble
++                        )
++            offset += count
++        if rows:
++            row_indices = async_tensor_h2d(rows, dtype=torch.long, device=logits.device)
++            token_indices = async_tensor_h2d(
++                tokens, dtype=torch.long, device=logits.device
++            )
++            logits[row_indices, token_indices] = -float("inf")
++
+     @staticmethod
+     def _find_last_sequence_index(target_list: list[int], token_ids: list[int]) -> int:
+         if not token_ids:
+diff --git a/vllm/v1/worker/gpu/sample/reasoning_eos.py b/vllm/v1/worker/gpu/sample/reasoning_eos.py
+new file mode 100644
+index 0000000..7fc8a25
+--- /dev/null
++++ b/vllm/v1/worker/gpu/sample/reasoning_eos.py
+@@ -0,0 +1,302 @@
++# SPDX-License-Identifier: Apache-2.0
++# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
++"""Incremental reasoning EOS masking for Model Runner V2."""
++
++import numpy as np
++import torch
++
++from vllm.config.reasoning import ReasoningConfig
++from vllm.sampling_params import SamplingParams
++from vllm.triton_utils import tl, triton
++from vllm.utils.torch_utils import async_tensor_h2d
++from vllm.v1.worker.gpu.buffer_utils import UvaBackedTensor
++from vllm.v1.worker.gpu.sample.thinking_budget import _load_effective_token
++from vllm.v1.worker.gpu.states import RequestState
++
++
++class ReasoningEOSState:
++    def __init__(self, req_states: RequestState, config: ReasoningConfig | None):
++        self.req_states = req_states
++        self.enabled = bool(getattr(config, "suppress_eos_in_reasoning", False))
++        self.use_guard = np.zeros(req_states.max_num_reqs, dtype=bool)
++        if not self.enabled:
++            return
++        assert config is not None
++        self.start_ids = torch.tensor(
++            config.reasoning_start_token_ids,
++            dtype=torch.int32,
++            device=req_states.device,
++        )
++        self.end_ids = torch.tensor(
++            config.natural_reasoning_end_token_ids,
++            dtype=torch.int32,
++            device=req_states.device,
++        )
++        self.eos_ids = torch.tensor(
++            config._eos_token_ids, dtype=torch.int32, device=req_states.device
++        )
++        self.tool_start = config._tool_start_token_id
++        self.tool_end = config._tool_end_token_id
++        prefix = "<function="
++        # 0: content, 1: reasoning, 2 + n: a tool opener followed by n prefix chars.
++        transitions = np.ones((len(prefix), req_states.vocab_size), dtype=np.int8)
++        for n in range(len(prefix)):
++            for token_id, text in config._tool_preamble_token_texts.items():
++                candidate = (prefix[:n] + text).lstrip()
++                if candidate.startswith(prefix):
++                    transitions[n, token_id] = 0
++                elif prefix.startswith(candidate):
++                    transitions[n, token_id] = 2 + len(candidate)
++        self.transitions = torch.tensor(transitions, device=req_states.device)
++        self.guard_enabled = UvaBackedTensor(req_states.max_num_reqs, dtype=torch.int32)
++        self.guard_enabled.np.fill(0)
++        self.guard_enabled.copy_to_uva()
++        self.phase = torch.zeros(
++            req_states.max_num_reqs, dtype=torch.int32, device=req_states.device
++        )
++        self.scan_pos = torch.zeros_like(self.phase)
++        self._reset_reqs: list[int] = []
++
++    def add_request(self, req_idx: int, params: SamplingParams) -> None:
++        if not self.enabled:
++            return
++        self.use_guard[req_idx] = not params.ignore_eos
++        self.guard_enabled.np[req_idx] = int(not params.ignore_eos)
++        self._reset_reqs.append(req_idx)
++
++    def apply_staged_writes(self) -> None:
++        if not self.enabled or not self._reset_reqs:
++            return
++        ids = async_tensor_h2d(
++            self._reset_reqs, dtype=torch.int64, device=self.req_states.device
++        )
++        self.phase.index_fill_(0, ids, 0)
++        self.scan_pos.index_fill_(0, ids, 0)
++        self.guard_enabled.copy_to_uva()
++        self._reset_reqs.clear()
++
++    def apply(
++        self,
++        logits,
++        expanded_idx_mapping,
++        idx_mapping,
++        idx_mapping_np,
++        input_ids,
++        expanded_local_pos,
++    ) -> None:
++        if not self.enabled or not np.any(self.use_guard[idx_mapping_np]):
++            return
++        shared = (
++            self.guard_enabled.gpu,
++            self.req_states.all_token_ids.gpu,
++            self.req_states.all_token_ids.gpu.stride(0),
++            self.req_states.total_len.gpu,
++            self.phase,
++            self.scan_pos,
++            self.start_ids,
++            self.end_ids,
++            self.transitions,
++        )
++        options = dict(
++            START_LEN=self.start_ids.numel(),
++            END_LEN=self.end_ids.numel(),
++            VOCAB=self.req_states.vocab_size,
++            TOOL_START=-1 if self.tool_start is None else self.tool_start,
++            TOOL_END=-1 if self.tool_end is None else self.tool_end,
++        )
++        _update_committed_phase[(idx_mapping.numel(),)](idx_mapping, *shared, **options)
++        _mask_reasoning_eos[(logits.shape[0],)](
++            logits,
++            logits.stride(0),
++            expanded_idx_mapping,
++            input_ids,
++            expanded_local_pos,
++            self.eos_ids,
++            *shared,
++            EOS_COUNT=self.eos_ids.numel(),
++            **options,
++        )
++
++
++@triton.jit
++def _advance_phase(
++    phase,
++    pos,
++    all_ids,
++    stride,
++    input_ids,
++    first,
++    req,
++    total,
++    start_ids,
++    end_ids,
++    transitions,
++    START_LEN: tl.constexpr,
++    END_LEN: tl.constexpr,
++    VOCAB: tl.constexpr,
++    TOOL_START: tl.constexpr,
++    TOOL_END: tl.constexpr,
++):
++    start_match = pos + 1 >= START_LEN
++    for j in tl.static_range(0, START_LEN):
++        if pos + 1 >= START_LEN:
++            actual = _load_effective_token(
++                all_ids, stride, input_ids, first, req, total, pos + 1 - START_LEN + j
++            )
++            start_match = start_match & (actual == tl.load(start_ids + j))
++    end_match = pos + 1 >= END_LEN
++    for j in tl.static_range(0, END_LEN):
++        if pos + 1 >= END_LEN:
++            actual = _load_effective_token(
++                all_ids, stride, input_ids, first, req, total, pos + 1 - END_LEN + j
++            )
++            end_match = end_match & (actual == tl.load(end_ids + j))
++    token = _load_effective_token(all_ids, stride, input_ids, first, req, total, pos)
++    if start_match:
++        phase = 1
++    elif end_match:
++        phase = 0
++    elif phase > 0 and token == TOOL_START:
++        phase = 2
++    elif phase >= 2:
++        if token == TOOL_END:
++            phase = 0
++        else:
++            phase = tl.load(transitions + (phase - 2) * VOCAB + token).to(tl.int32)
++    return phase
++
++
++@triton.jit
++def _update_committed_phase(
++    req_ids,
++    enabled,
++    all_ids,
++    stride,
++    total_lens,
++    phases,
++    scan_positions,
++    start_ids,
++    end_ids,
++    transitions,
++    START_LEN: tl.constexpr,
++    END_LEN: tl.constexpr,
++    VOCAB: tl.constexpr,
++    TOOL_START: tl.constexpr,
++    TOOL_END: tl.constexpr,
++    BLOCK: tl.constexpr = 1024,
++):
++    req = tl.load(req_ids + tl.program_id(0))
++    if tl.load(enabled + req) == 0:
++        return
++    total = tl.load(total_lens + req)
++    scan = tl.load(scan_positions + req)
++    phase = tl.load(phases + req)
++    if scan == 0 or scan > total:
++        # Most prompts end in a reasoning marker. Find the latest marker in
++        # parallel blocks, then inspect only the following tool preamble/text.
++        last_start = -1
++        last_end = -1
++        hi = total
++        while hi > 0 and last_start < 0 and last_end < 0:
++            lo = tl.maximum(0, hi - BLOCK)
++            offs = lo + tl.arange(0, BLOCK)
++            sm = (offs < hi) & (offs + START_LEN <= total)
++            em = (offs < hi) & (offs + END_LEN <= total)
++            for j in tl.static_range(0, START_LEN):
++                token = tl.load(
++                    all_ids + req * stride + offs + j, mask=offs + j < total, other=-1
++                )
++                sm = sm & (token == tl.load(start_ids + j))
++            for j in tl.static_range(0, END_LEN):
++                token = tl.load(
++                    all_ids + req * stride + offs + j, mask=offs + j < total, other=-1
++                )
++                em = em & (token == tl.load(end_ids + j))
++            last_start = tl.max(tl.where(sm, offs, -1), axis=0)
++            last_end = tl.max(tl.where(em, offs, -1), axis=0)
++            hi = lo
++        phase = tl.where(last_start > last_end, 1, 0)
++        scan = tl.where(
++            last_start > last_end,
++            last_start + START_LEN,
++            tl.where(last_end >= 0, last_end + END_LEN, total),
++        )
++    for pos in tl.range(scan, total):
++        phase = _advance_phase(
++            phase,
++            pos,
++            all_ids,
++            stride,
++            all_ids,
++            0,
++            req,
++            total,
++            start_ids,
++            end_ids,
++            transitions,
++            START_LEN,
++            END_LEN,
++            VOCAB,
++            TOOL_START,
++            TOOL_END,
++        )
++    tl.store(phases + req, phase)
++    tl.store(scan_positions + req, total)
++
++
++@triton.jit
++def _mask_reasoning_eos(
++    logits,
++    logits_stride,
++    expanded_req_ids,
++    input_ids,
++    local_positions,
++    eos_ids,
++    enabled,
++    all_ids,
++    stride,
++    total_lens,
++    phases,
++    scan_positions,
++    start_ids,
++    end_ids,
++    transitions,
++    EOS_COUNT: tl.constexpr,
++    START_LEN: tl.constexpr,
++    END_LEN: tl.constexpr,
++    VOCAB: tl.constexpr,
++    TOOL_START: tl.constexpr,
++    TOOL_END: tl.constexpr,
++):
++    row = tl.program_id(0)
++    req = tl.load(expanded_req_ids + row)
++    if tl.load(enabled + req) == 0:
++        return
++    total = tl.load(total_lens + req)
++    local_pos = tl.load(local_positions + row)
++    phase = tl.load(phases + req)
++    first = row - local_pos
++    # Draft prefixes affect only this row, never the committed phase cache.
++    for pos in tl.range(total, total + local_pos):
++        phase = _advance_phase(
++            phase,
++            pos,
++            all_ids,
++            stride,
++            input_ids,
++            first,
++            req,
++            total,
++            start_ids,
++            end_ids,
++            transitions,
++            START_LEN,
++            END_LEN,
++            VOCAB,
++            TOOL_START,
++            TOOL_END,
++        )
++    if phase > 0:
++        for i in tl.static_range(0, EOS_COUNT):
++            eos = tl.load(eos_ids + i)
++            tl.store(logits + row * logits_stride + eos, -float("inf"))
+diff --git a/vllm/v1/worker/gpu/sample/sampler.py b/vllm/v1/worker/gpu/sample/sampler.py
+index 3ee2c13..a581a7b 100644
+--- a/vllm/v1/worker/gpu/sample/sampler.py
++++ b/vllm/v1/worker/gpu/sample/sampler.py
+@@ -24,6 +24,7 @@ from vllm.v1.worker.gpu.sample.logprob import (
+ )
+ from vllm.v1.worker.gpu.sample.output import SamplerOutput, SamplingMaskTensors
+ from vllm.v1.worker.gpu.sample.penalties import PenaltiesState
++from vllm.v1.worker.gpu.sample.reasoning_eos import ReasoningEOSState
+ from vllm.v1.worker.gpu.sample.states import NO_LOGPROBS, SamplingStates
+ from vllm.v1.worker.gpu.sample.thinking_budget import ThinkingBudgetState
+ from vllm.v1.worker.gpu.sample.trace_replay import TraceReplayState
+@@ -55,6 +56,7 @@ class Sampler:
+         self.bad_words_state = BadWordsState(req_states)
+         self.logprob_token_ids_state = LogprobTokenIdsState(max_num_reqs, device)
+         self.thinking_budget_state = ThinkingBudgetState(req_states, reasoning_config)
++        self.reasoning_eos_state = ReasoningEOSState(req_states, reasoning_config)
+         self.trace_replay_state = (
+             TraceReplayState(req_states) if enable_trace_replay else None
+         )
+@@ -74,13 +76,15 @@ class Sampler:
+         self.bad_words_state.add_request(req_idx, sampling_params)
+         self.logprob_token_ids_state.add_request(req_idx, sampling_params)
+         self.thinking_budget_state.add_request(req_idx, sampling_params)
++        self.reasoning_eos_state.add_request(req_idx, sampling_params)
+         if self.trace_replay_state is not None:
+             self.trace_replay_state.add_request(req_idx, sampling_params)
+ 
+         states = self.sampling_states
+         temperature = states.temperature.np[req_idx]
+         self.needs_logits_processing[req_idx] = (
+-            self.logit_bias_state.use_logit_bias[req_idx]
++            self.reasoning_eos_state.use_guard[req_idx]
++            or self.logit_bias_state.use_logit_bias[req_idx]
+             or self.penalties_state.use_penalty[req_idx]
+             or self.bad_words_state.num_bad_words.np[req_idx] > 0
+             or (
+@@ -100,6 +104,7 @@ class Sampler:
+         self.bad_words_state.apply_staged_writes()
+         self.logprob_token_ids_state.apply_staged_writes()
+         self.thinking_budget_state.apply_staged_writes()
++        self.reasoning_eos_state.apply_staged_writes()
+         if self.trace_replay_state is not None:
+             self.trace_replay_state.apply_staged_writes()
+ 
+@@ -244,6 +249,15 @@ class Sampler:
+             expanded_local_pos,
+         )
+ 
++        self.reasoning_eos_state.apply(
++            logits,
++            expanded_idx_mapping,
++            idx_mapping,
++            idx_mapping_np,
++            input_ids,
++            expanded_local_pos,
++        )
++
+         # Force the reasoning end marker once a request's thinking budget is
+         # reached; applied before temperature so the forced token is always kept.
+         self.thinking_budget_state.apply(

--- a/src/patches/v029-reasoning-regressions.patch
+++ b/src/patches/v029-reasoning-regressions.patch
@@ -1,0 +1,357 @@
+diff --git a/tests/parser/engine/test_qwen3_reasoning.py b/tests/parser/engine/test_qwen3_reasoning.py
+index a9bec49..eba945e 100644
+--- a/tests/parser/engine/test_qwen3_reasoning.py
++++ b/tests/parser/engine/test_qwen3_reasoning.py
+@@ -16,11 +16,13 @@ import pytest
+ from tests.parser.engine.conftest import make_mock_tokenizer
+ from tests.parser.engine.streaming_helpers import simulate_reasoning_streaming
+ from vllm.parser.abstract_parser import DelegatingParser
++from vllm.parser.engine.events import EventType
+ from vllm.parser.engine.parser_engine_config import ParserState
+ from vllm.parser.engine.registered_adapters import (
+     Qwen3ParserReasoningAdapter,
+     Qwen3ParserToolAdapter,
+ )
++from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
+ from vllm.parser.qwen3 import Qwen3Parser, qwen3_config
+ 
+ _THINK_START_ID = 50
+@@ -56,7 +58,53 @@ def parser(mock_tokenizer):
+     return Qwen3Parser(mock_tokenizer)
+ 
+ 
++@pytest.mark.parametrize("thinking", [True, False])
++@pytest.mark.parametrize("chunk_size", [1, 7, 1000])
++def test_malformed_tool_preamble_is_lossless_across_chunks(thinking, chunk_size):
++    text = "Quoted `<tool_call>` prose </tool_call> still visible."
++    engine = StreamingParserEngine(qwen3_config(thinking=thinking), None)
++    events = []
++    for offset in range(0, len(text), chunk_size):
++        events.extend(engine.feed(text[offset : offset + chunk_size], []))
++    events.extend(engine.finish())
++    kind = EventType.REASONING_CHUNK if thinking else EventType.TEXT_CHUNK
++    assert "".join(e.value for e in events if e.type == kind) == text
++    assert not any(e.type == EventType.TOOL_CALL_START for e in events)
++
++
++def test_malformed_special_token_then_real_tool_preserves_tool_index(mock_tokenizer):
++    engine = StreamingParserEngine(qwen3_config(), mock_tokenizer)
++    events = engine.feed("<tool_call>", [_TOOL_CALL_ID])
++    assert not events
++    events += engine.feed("` quoted marker. ", [])
++    events += engine.feed("<tool_call>", [_TOOL_CALL_ID])
++    events += engine.feed("\n<function=bash><parameter=cmd>pwd</parameter>", [])
++    events += engine.feed("</function></tool_call>", [_TOOL_CALL_END_ID])
++    events += engine.finish()
++    assert (
++        "".join(e.value for e in events if e.type == EventType.REASONING_CHUNK)
++        == "<tool_call>` quoted marker. "
++    )
++    starts = [e for e in events if e.type == EventType.TOOL_CALL_START]
++    assert len(starts) == 1
++    assert starts[0].tool_index == 0
++    assert "".join(e.value for e in events if e.type == EventType.TOOL_NAME) == "bash"
++
++
+ class TestNonStreaming:
++    @pytest.mark.parametrize(
++        "candidate",
++        [
++            "<tool_call>` ordinary prose continues",
++            "<tool_call>quoted text</tool_call>",
++        ],
++    )
++    def test_malformed_tool_preamble_preserves_reasoning(self, parser, candidate):
++        text = "The literal marker is `" + candidate
++        reasoning, content = parser.extract_reasoning(text, None)
++        assert reasoning == text
++        assert content is None
++
+     def test_reasoning_then_content(self, parser):
+         text = "<think>Let me analyze.</think>The answer is 42."
+         reasoning, content = parser.extract_reasoning(text, None)
+@@ -261,6 +309,19 @@ class TestIsReasoningEndTurnBoundaries:
+         parser = Qwen3Parser(make_mock_tokenizer(vocab))
+         assert parser.is_reasoning_end([_TEXT_ID, _THINK_END_ID, _TEXT_ID])
+ 
++    def test_boundary_with_thinking_disabled_is_end(self, mock_tokenizer):
++        """With thinking disabled (initial state CONTENT) a walk that stops at a turn
++        boundary must report reasoning as ended: the model never emits a marker."""
++        parser = Qwen3Parser(
++            mock_tokenizer, chat_template_kwargs={"enable_thinking": False}
++        )
++        assert parser.is_reasoning_end([_IM_START_ID, _TEXT_ID])
++
++    def test_boundary_with_thinking_enabled_not_end(self, parser):
++        """With thinking disabled (initial state REASONING) a walk that stops at a turn
++        boundary must keep reasoning open"""
++        assert not parser.is_reasoning_end([_IM_START_ID, _TEXT_ID])
++
+ 
+ class TestDelegatingPromptDetection:
+     def test_prompt_tool_example_does_not_skip_streaming_reasoning(
+diff --git a/tests/v1/sample/test_thinking_budget_state.py b/tests/v1/sample/test_thinking_budget_state.py
+index 943734e..561d31b 100644
+--- a/tests/v1/sample/test_thinking_budget_state.py
++++ b/tests/v1/sample/test_thinking_budget_state.py
+@@ -2,6 +2,7 @@
+ # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+ """Unit tests for ThinkingBudgetStateHolder batch index moves."""
+ 
++import pytest
+ import torch
+ 
+ from vllm.sampling_params import SamplingParams
+@@ -93,3 +94,109 @@ def test_swap_exchanges_two_budgeted_states():
+     )
+     assert h._state[0]["thinking_token_budget"] == b1
+     assert h._state[1]["thinking_token_budget"] == b0
++
++
++class _EOSGuardConfig(_MockReasoningConfig):
++    suppress_eos_in_reasoning = True
++    reasoning_start_token_ids = [10]
++    reasoning_end_token_ids = [11]
++    natural_reasoning_end_token_ids = [11]
++    _eos_token_ids = [1, 2]
++    _tool_start_token_id = 12
++    _tool_end_token_id = 13
++    _tool_preamble_token_texts = {14: "<function=", 15: "\n", 17: "<function", 18: "="}
++
++
++@pytest.mark.parametrize("device", ["cpu", "cuda"])
++@pytest.mark.parametrize("draft_count", [0, 2, 3, 4])
++def test_eos_guard_preserves_reasoning_and_restores_normal_stop(device, draft_count):
++    """An unbudgeted request masks only model EOS, until a natural transition."""
++    if device == "cuda" and not torch.cuda.is_available():
++        pytest.skip("CUDA unavailable")
++    h = ThinkingBudgetStateHolder(
++        _EOSGuardConfig(), 2, draft_count, torch.device(device), False
++    )
++    h.sync_batch(BatchUpdate(1, (), [(0, SamplingParams(), [10], [])], ()))
++    draft = [[7] * draft_count]
++    h.update_state([[]], draft)
++    logits = torch.zeros(1, 20, device=device)
++    h.apply_to_logits(logits, True, draft)
++    assert torch.isneginf(logits[0, [1, 2]]).all()
++    assert torch.equal(logits[0, 3:], torch.zeros(17, device=device))
++    for end_tokens in ([11], [12, 14]):
++        h.sync_batch(BatchUpdate(1, (0,), [(0, SamplingParams(), [10], [])], ()))
++        h.update_state([[7, *end_tokens]], draft)
++        logits.zero_()
++        h.apply_to_logits(logits, True, draft)
++        assert (logits == 0).all()
++
++
++@pytest.mark.parametrize("draft", [[[7, 11, 7]], [[12, 14, 7]]])
++def test_eos_guard_uses_each_draft_prefix_without_committing_rejected_drafts(draft):
++    h = ThinkingBudgetStateHolder(_EOSGuardConfig(), 2, 3, torch.device("cpu"), False)
++    h.sync_batch(BatchUpdate(1, (), [(0, SamplingParams(), [10], [])], ()))
++    h.update_state([[]], draft)
++    bonus = h.apply_to_logits(torch.zeros(1, 20), True, draft)
++    target = h.apply_to_logits(torch.zeros(3, 20), False, draft)
++    assert (bonus == 0).all()
++    assert torch.isneginf(target[:2, [1, 2]]).all()
++    assert (target[2] == 0).all()
++    # The closing draft was rejected; only the first text token was committed.
++    h.update_state([[7]], [[7, 7, 7]])
++    bonus = h.apply_to_logits(torch.zeros(1, 20), True, [[7, 7, 7]])
++    assert torch.isneginf(bonus[0, [1, 2]]).all()
++
++
++def test_eos_guard_survives_batch_move_and_generated_reasoning_start():
++    h = ThinkingBudgetStateHolder(_EOSGuardConfig(), 2, 0, torch.device("cpu"), False)
++    h.sync_batch(BatchUpdate(2, (), [(0, SamplingParams(), [7], [])], ()))
++    h.update_state([[]], None)
++    assert (h.apply_to_logits(torch.zeros(1, 20), False, None) == 0).all()
++    h.update_state([[10, 7]], None)
++    h.sync_batch(BatchUpdate(2, (), (), [(0, 1, MoveDirectionality.SWAP)]))
++    h.update_state([[], [10, 7]], None)
++    logits = h.apply_to_logits(torch.zeros(2, 20), False, None)
++    assert (logits[0] == 0).all()
++    assert torch.isneginf(logits[1, [1, 2]]).all()
++
++
++def test_eos_guard_keeps_explicit_thinking_budget():
++    h = ThinkingBudgetStateHolder(_EOSGuardConfig(), 1, 0, torch.device("cpu"), False)
++    params = SamplingParams(thinking_token_budget=1)
++    h.sync_batch(BatchUpdate(1, (), [(0, params, [10], [])], ()))
++    h.update_state([[7]], None)
++    logits = h.apply_to_logits(torch.zeros(1, 20), False, None)
++    assert logits.argmax(-1).item() == 11
++    assert torch.isneginf(logits[0, [1, 2]]).all()
++
++
++def test_eos_guard_preserves_explicit_ignore_eos():
++    h = ThinkingBudgetStateHolder(_EOSGuardConfig(), 1, 0, torch.device("cpu"), False)
++    params = SamplingParams(ignore_eos=True)
++    h.sync_batch(BatchUpdate(1, (), [(0, params, [10], [])], ()))
++    h.update_state([[]], None)
++    assert (h.apply_to_logits(torch.zeros(1, 20), False, None) == 0).all()
++
++
++@pytest.mark.parametrize("draft_count", [0, 2, 3, 4])
++def test_quoted_tool_opener_keeps_reasoning_eos_masked(draft_count):
++    h = ThinkingBudgetStateHolder(
++        _EOSGuardConfig(), 1, draft_count, torch.device("cpu"), False
++    )
++    h.sync_batch(BatchUpdate(1, (), [(0, SamplingParams(), [10], [])], ()))
++    # The token following the tool opener is prose, not a function header.
++    output = [12, 16, 7]
++    draft = [[7] * draft_count]
++    h.update_state([output], draft)
++    assert torch.isneginf(
++        h.apply_to_logits(torch.zeros(1, 20), True, draft)[0, [1, 2]]
++    ).all()
++    # A subsequent genuine header may span tokens and decode steps.
++    output += [12, 15, 17]
++    h.update_state([output], draft)
++    assert torch.isneginf(
++        h.apply_to_logits(torch.zeros(1, 20), True, draft)[0, [1, 2]]
++    ).all()
++    output += [18]
++    h.update_state([output], draft)
++    assert (h.apply_to_logits(torch.zeros(1, 20), True, draft) == 0).all()
+diff --git a/tests/v1/worker/test_gpu_thinking_budget.py b/tests/v1/worker/test_gpu_thinking_budget.py
+index 2bc697b..8c4339d 100644
+--- a/tests/v1/worker/test_gpu_thinking_budget.py
++++ b/tests/v1/worker/test_gpu_thinking_budget.py
+@@ -299,3 +299,138 @@ def test_v2_thinking_budget_continues_end_prefix_from_prompt():
+ 
+     assert out[0, END_B] == pytest.approx(1.0e9)
+     assert out[0, END_A] == 0
++
++
++class MockEOSGuardConfig(MockReasoningConfig):
++    suppress_eos_in_reasoning = True
++    _eos_token_ids = [1, 2]
++    _tool_start_token_id = 94
++    _tool_end_token_id = 95
++    _tool_preamble_token_texts = {96: "<function=", 97: "\n", 98: "<function", 99: "="}
++
++
++@pytest.mark.parametrize("draft_count", [0, 2, 3, 4])
++@pytest.mark.parametrize(
++    "tail,active",
++    [
++        ([10], True),
++        ([END], False),
++        ([94, 96], False),
++        ([94, 60, 95, 10], True),
++        ([94, 97, 98], True),
++        ([94, 97, 98, 99], False),
++        ([94, 95], False),
++    ],
++)
++def test_v2_eos_guard_preserves_reasoning_and_tool_transitions(
++    draft_count, tail, active
++):
++    from vllm.v1.worker.gpu.sample.reasoning_eos import ReasoningEOSState
++
++    tokens = [START, *tail]
++    req_states = _make_req_states(tokens)
++    state = ReasoningEOSState(req_states, MockEOSGuardConfig())
++    state.add_request(3, SamplingParams())
++    state.apply_staged_writes()
++    logits = torch.zeros(draft_count + 1, VOCAB_SIZE, device=DEVICE)
++    out = _apply(
++        state, logits, [tokens[-1]] + [10] * draft_count, list(range(draft_count + 1))
++    )
++    assert torch.isneginf(out[:, [1, 2]]).all().item() is active
++    assert (out[:, 3:] == 0).all()
++
++
++@pytest.mark.parametrize("draft", [[10, END, 10], [94, 96, 10]])
++def test_v2_eos_guard_does_not_commit_rejected_draft_transition(draft):
++    from vllm.v1.worker.gpu.sample.reasoning_eos import ReasoningEOSState
++
++    req_states = _make_req_states([START, 10])
++    state = ReasoningEOSState(req_states, MockEOSGuardConfig())
++    state.add_request(3, SamplingParams())
++    state.apply_staged_writes()
++    out = _apply(
++        state, torch.zeros(4, VOCAB_SIZE, device=DEVICE), [10, *draft], [0, 1, 2, 3]
++    )
++    assert torch.isneginf(out[:2, [1, 2]]).all()
++    assert (out[2:] == 0).all()
++    # Only ordinary text is committed after rejection of the transition.
++    req_states.all_token_ids.stage_write(3, 2, [10])
++    req_states.total_len.stage_write_elem(3, 3)
++    req_states.apply_staged_writes()
++    out = _apply(state, torch.zeros(1, VOCAB_SIZE, device=DEVICE), [10], [0])
++    assert torch.isneginf(out[0, [1, 2]]).all()
++
++
++def test_v2_eos_guard_resumes_partial_header_and_resets_reused_slot():
++    from vllm.v1.worker.gpu.sample.reasoning_eos import ReasoningEOSState
++
++    req_states = _make_req_states([START, 94, 98])
++    state = ReasoningEOSState(req_states, MockEOSGuardConfig())
++    state.add_request(3, SamplingParams())
++    state.apply_staged_writes()
++    out = _apply(state, torch.zeros(1, VOCAB_SIZE, device=DEVICE), [98], [0])
++    assert torch.isneginf(out[0, [1, 2]]).all()
++    req_states.all_token_ids.stage_write(3, 3, [99])
++    req_states.total_len.stage_write_elem(3, 4)
++    req_states.apply_staged_writes()
++    out = _apply(state, torch.zeros(1, VOCAB_SIZE, device=DEVICE), [99], [0])
++    assert (out == 0).all()
++    req_states.remove_request("req")
++    req_states.add_request("next", 1, [START], 1, 32)
++    req_states.apply_staged_writes()
++    state.add_request(3, SamplingParams())
++    state.apply_staged_writes()
++    out = _apply(state, torch.zeros(1, VOCAB_SIZE, device=DEVICE), [START], [0])
++    assert torch.isneginf(out[0, [1, 2]]).all()
++
++
++@pytest.mark.parametrize("ignore_eos", [False, True])
++def test_v2_greedy_sampler_applies_eos_guard_and_honors_ignore_eos(ignore_eos):
++    req_states = _make_req_states([START, 10])
++    sampler = Sampler(
++        4, VOCAB_SIZE, DEVICE, req_states, reasoning_config=MockEOSGuardConfig()
++    )
++    sampler.add_request(3, 1, SamplingParams(temperature=0, ignore_eos=ignore_eos))
++    sampler.apply_staged_writes()
++    ids = torch.tensor([3], dtype=torch.int32, device=DEVICE)
++    out = sampler.apply_sampling_params(
++        torch.zeros(1, VOCAB_SIZE, device=DEVICE),
++        ids,
++        ids,
++        ids.cpu().numpy(),
++        torch.tensor([1], device=DEVICE),
++        torch.tensor([10], dtype=torch.int32, device=DEVICE),
++        torch.tensor([0], dtype=torch.int32, device=DEVICE),
++    ).cpu()
++    assert torch.isneginf(out[0, [1, 2]]).all().item() is not ignore_eos
++
++
++@pytest.mark.parametrize("prefix_len", [0, 2051, 262100])
++def test_v2_eos_guard_finds_markers_in_long_prompts(prefix_len):
++    from vllm.v1.worker.gpu.sample.reasoning_eos import ReasoningEOSState
++
++    tokens = [10] * prefix_len + [START, 94, 60, 10]
++    req_states = _make_req_states(tokens, prompt_len=len(tokens))
++    state = ReasoningEOSState(req_states, MockEOSGuardConfig())
++    state.add_request(3, SamplingParams())
++    state.apply_staged_writes()
++    out = _apply(state, torch.zeros(1, VOCAB_SIZE, device=DEVICE), [10], [0])
++    assert torch.isneginf(out[0, [1, 2]]).all()
++    assert state.scan_pos[3].item() == len(tokens)
++
++
++def test_v2_eos_guard_multi_token_markers_cross_draft_boundary():
++    from vllm.v1.worker.gpu.sample.reasoning_eos import ReasoningEOSState
++
++    config = MockEOSGuardConfig()
++    config.reasoning_start_token_ids = [START, END_A]
++    config.natural_reasoning_end_token_ids = [END_A, END_B]
++    req_states = _make_req_states([START, END_A, 10, END_A])
++    state = ReasoningEOSState(req_states, config)
++    state.add_request(3, SamplingParams())
++    state.apply_staged_writes()
++    out = _apply(
++        state, torch.zeros(2, VOCAB_SIZE, device=DEVICE), [END_A, END_B], [0, 1]
++    )
++    assert torch.isneginf(out[0, [1, 2]]).all()
++    assert (out[1] == 0).all()


### PR DESCRIPTION
Qwen can sample EOS while it is still reasoning, returning HTTP 200 with no answer. Separately, a quoted malformed `<tool_call>` can put the parser into tool mode and silently discard following prose.

This adds two v0.29 runtime patches and their regression tests:

- Preserve malformed tool openers and following prose in the original channel; retain valid Qwen tool parsing.
- Add `REASONING_EOS_GUARD=1` as an opt-in launcher setting. Both model runners mask model EOS while reasoning is open, restore it on natural reasoning endings or validated tool transitions, and track each speculative prefix without committing rejected drafts. The guard does not force `</think>`, insert an answer or set a thinking budget. It honors `ignore_eos` and existing output limits.

The preview image and default EOS behavior are unchanged. Masking EOS changes the sampling distribution while reasoning is open, so answer quality still needs workload evaluation. EOS in final-answer text remains a protocol terminator.

Related: vllm-project/vllm#55420 and vllm-project/vllm#55562. That open PR implements `stop` / `force_end`; this is a deployable v0.29 alternative that lets reasoning continue naturally and validates Qwen's tool preamble before treating it as an implicit reasoning end. No existing PR in this repository covers these changes.

Validation:

- Built this exact Dockerfile from the official ARM64 v0.29 image; both runtime patches apply without fuzz.
- Ran `.venv/bin/python -m pytest --confcutdir=tests/parser/engine tests/parser/engine tests/v1/sample/test_thinking_budget_state.py tests/v1/worker/test_gpu_thinking_budget.py -q --tb=short` against the resulting image: **3,881 passed**.
- GPU tests cover MTP 2/3/4, rejected draft transitions, reused slots, multi-token markers, greedy processing and a 262,104-token prompt. Real Qwen tokenizer checks cover quoted openers, proper function headers and natural endings.
- Live DGX Spark checks pass for constrained EOS masking/restoration, a valid tool round trip and an image query. A replay reached the final channel; literal EOS there still terminates the answer, as documented above. Reasoning can also exhaust the requested output budget without producing a final answer. Live context-boundary and cold-to-warm prefix-cache checks also pass. Broader quality and performance evaluation remains in progress.

AI assistance was used to diagnose, implement and test these changes.
