### PR TITLE
Download knobs (EXCLUDE / MAX_WORKERS / XET), PLE Prometheus counters, KV_CACHE_MEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,23 @@ to `qwen38-flash` and `18300`, like `serve.sh`.
 - The base image is multi-arch, so `docker build` also works on x86 Blackwell
   (sm_120, e.g. RTX PRO 6000) for testing, though this is tuned for the Spark.
 
+**Download speed.** `scripts/download-weights.sh` disables the Xet backend, because it
+stalled on some Spark setups. That is a stability choice, not a speed one, and on a fast
+link it costs a lot: `--max-workers` parallelises across *files*, so a checkpoint that is
+a dozen large shards leaves most of a gigabit idle. Measured on a DGX Spark on gigabit
+fibre, pulling 81 GB:
+
+| | rate | 81 GB takes |
+|---|---|---|
+| plain HTTPS, 8 workers (default) | 14.7 MB/s (117 Mbit/s) | ~92 min |
+| `XET=1` | **101 MB/s (809 Mbit/s)** | **13.4 min** |
+
+`XET=1` opts back in, and Xet-backed repos are the ones whose API tree entries carry an
+`xetHash`. It stays off by default because that run still ended in an `httpx.ReadTimeout`
+*after* the last file completed — every blob was intact, but the exit code was non-zero,
+so anything that trusts it will think the download failed. Re-run to confirm; it is
+resumable, and a finished download re-checks in seconds.
+
 ## Quickstart
 
 The commands are in the [TL;DR](#tldr--run-it-on-a-dgx-spark) at the top. Once the log says
@@ -758,7 +775,7 @@ src/patch_qsa_fp8_kv.py           7. fp8_e4m3 KV cache on the QSA path (by @Nane
 src/test_ple_mmap_cpu.py          CPU unit test for the gather (no GPU needed)
 src/test_qsa_exact_topk_cpu.py    CPU unit test for the exact top-k (no GPU needed)
 tools/fp8_convert.py              side-layer bf16 -> blockwise fp8 (by @Saren-Arterius)
-scripts/download-weights.sh
+scripts/download-weights.sh       MODEL, EXCLUDE, MAX_WORKERS, XET
 scripts/prepare-hybrid.sh         one-time: build the -fp8hybrid snapshot
 scripts/prepare-mtp-graft.sh      one-time: graft the NVFP4 MTP draft experts onto it (MODE=hybrid-mtp)
 tools/vllm_watch.py               live per-session view of prompts / reasoning / outputs / stats (needs LOG_REQUESTS=1; @0x3dlux)

--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ Full port notes in [docs/HOW-IT-WORKS.md](docs/HOW-IT-WORKS.md#the-vllm-v0290-po
 | `PREWARM` | `0` | `1` streams the 48 GiB table once at boot to warm the page cache — steadier first-request latency, ~10 s extra startup. |
 | `WORKERS` | `32` | Threads used for the mmap gather (only used above `VLLM_PLE_MMAP_FAST_ROWS`=512 unique rows; decode-sized gathers run inline). |
 | `LOG_REQUESTS` | `0` | `1` logs every prompt and output (`VLLM_LOGGING_LEVEL=DEBUG --enable-log-requests --enable-log-outputs`) so `tools/vllm_watch.py` can show sessions live. Debugging only: it puts user content in the Docker log, unbounded. |
+| `PROM_MULTIPROC` | `0` | `1` runs prometheus_client in multiprocess mode so engine-side metrics (`vllm:ple_mmap_*`) reach `/metrics`. Opt-in, because it stops vLLM exporting its `*_created` samples; see *Watching the mmapped table* below. |
 | `KV_CACHE_MEM` | | Passed through as `--kv-cache-memory-bytes`. `GPU_MEM` is a fraction of *total* device memory, so it leaves whatever was already resident on the table; vLLM prints the exact figure it would accept at startup ("Replace gpu_memory_utilization config with `--kv-cache-memory=...`"). On a Spark that headroom is also what the page cache uses for the PLE table, so taking it is a trade, not free memory — watch `vllm:ple_mmap_gather_seconds_total` when you do. |
 | `EXTRA` | | Extra vLLM flags, passed verbatim — e.g. `--long-prefill-token-threshold 1024` for multi-client responsiveness (see [the concurrency section](#decoding-clients-stall-while-other-clients-prefill-the-long-prefill-token-threshold-slider)), `--api-key <secret>`. |
 
@@ -603,9 +604,19 @@ vllm:ple_mmap_rows_total             rows gathered
 vllm:ple_mmap_bytes_total            bytes read from the table
 ```
 
-They are registered in the EngineCore process and reach `/metrics` through
-prometheus_client's `MultiProcessCollector`, which vLLM already sets up. The three
-views worth graphing:
+They are registered in the EngineCore process, so they only reach `/metrics` when
+prometheus_client runs in multiprocess mode. vLLM turns that on only for
+`api_server_count > 1`; `scripts/serve.sh` does it for the single-server setup used here when you opt in with
+`PROM_MULTIPROC=1`, by pointing `PROMETHEUS_MULTIPROC_DIR` at a fresh tmpfs.
+
+Switching to multiprocess mode was checked against a live server by diffing the
+complete `/metrics` before and after: vLLM's other 71 metric families are exported with
+identical label sets and no per-process `pid` label. The only loss is the 35
+`*_created` families, which prometheus_client does not export in multiprocess mode; that is why
+exporting the counters is opt-in, so nothing changes for existing dashboards unless you
+ask for it.
+
+The three views worth graphing:
 
 ```promql
 rate(vllm:ple_mmap_op_seconds_total[5m]) / rate(vllm:ple_mmap_lookup_ops_total[5m])

--- a/README.md
+++ b/README.md
@@ -567,7 +567,39 @@ Full port notes in [docs/HOW-IT-WORKS.md](docs/HOW-IT-WORKS.md#the-vllm-v0290-po
 | `PREWARM` | `0` | `1` streams the 48 GiB table once at boot to warm the page cache — steadier first-request latency, ~10 s extra startup. |
 | `WORKERS` | `32` | Threads used for the mmap gather (only used above `VLLM_PLE_MMAP_FAST_ROWS`=512 unique rows; decode-sized gathers run inline). |
 | `LOG_REQUESTS` | `0` | `1` logs every prompt and output (`VLLM_LOGGING_LEVEL=DEBUG --enable-log-requests --enable-log-outputs`) so `tools/vllm_watch.py` can show sessions live. Debugging only: it puts user content in the Docker log, unbounded. |
+| `KV_CACHE_MEM` | | Passed through as `--kv-cache-memory-bytes`. `GPU_MEM` is a fraction of *total* device memory, so it leaves whatever was already resident on the table; vLLM prints the exact figure it would accept at startup ("Replace gpu_memory_utilization config with `--kv-cache-memory=...`"). On a Spark that headroom is also what the page cache uses for the PLE table, so taking it is a trade, not free memory — watch `vllm:ple_mmap_gather_seconds_total` when you do. |
 | `EXTRA` | | Extra vLLM flags, passed verbatim — e.g. `--long-prefill-token-threshold 1024` for multi-client responsiveness (see [the concurrency section](#decoding-clients-stall-while-other-clients-prefill-the-long-prefill-token-threshold-slider)), `--api-key <secret>`. |
+
+### Watching the mmapped table (`vllm:ple_mmap_*`)
+
+The PLE table is the one component whose cost depends on runtime state rather than
+configuration: how much of its 47.7 GiB the page cache is holding decides your prefill
+speed, and that moves as the KV pool, the request mix and the OS all pull on the same
+unified memory. The module exports five counters so this is visible on a dashboard
+rather than only in a windowed log line that a container restart destroys:
+
+```
+vllm:ple_mmap_lookup_ops_total       lookups (hash + gather + H2D)
+vllm:ple_mmap_op_seconds_total       cumulative seconds in the lookup op
+vllm:ple_mmap_gather_seconds_total   cumulative seconds in the row gather (disk reads)
+vllm:ple_mmap_rows_total             rows gathered
+vllm:ple_mmap_bytes_total            bytes read from the table
+```
+
+They are registered in the EngineCore process and reach `/metrics` through
+prometheus_client's `MultiProcessCollector`, which vLLM already sets up. The three
+views worth graphing:
+
+```promql
+rate(vllm:ple_mmap_op_seconds_total[5m]) / rate(vllm:ple_mmap_lookup_ops_total[5m])
+rate(vllm:ple_mmap_gather_seconds_total[5m]) / rate(vllm:ple_mmap_op_seconds_total[5m])
+rate(vllm:ple_mmap_bytes_total[5m])
+```
+
+The middle one is the page-cache health signal — the share of each lookup spent waiting
+on disk. It climbs as the cache is squeezed and falls as the hot region settles in. Pair
+it with `Cached` from a node exporter, since nothing in vLLM's own metrics exposes the
+quantity that actually governs it. `VLLM_PLE_MMAP_PROMETHEUS=0` turns the counters off.
 
 ## Throughput and concurrency
 

--- a/scripts/download-weights.sh
+++ b/scripts/download-weights.sh
@@ -1,16 +1,61 @@
 #!/usr/bin/env bash
-# Download the NVFP4 checkpoint (~126 GiB, 135 GB) into the local Hugging Face cache.
-# Resumable — safe to re-run if the connection drops.
+# Download a Qwen3.8-Flash-Next checkpoint into the local Hugging Face cache.
+# Resumable — safe to re-run if the connection drops, and safe to interrupt: partial
+# blobs are kept as .incomplete and resumed where they left off.
 #
-#   scripts/download-weights.sh
+#   scripts/download-weights.sh                    # the default NVFP4 checkpoint (~126 GiB, 135 GB)
+#   MODEL=<org/name> scripts/download-weights.sh   # some other checkpoint
+#   MODEL=<org/name> EXCLUDE='glob1 glob2' scripts/download-weights.sh
+#   MAX_WORKERS=24 scripts/download-weights.sh     # more parallel connections
+#   XET=1 scripts/download-weights.sh              # Xet backend (see the caution below)
 #
-# Needs ~140 GB free on the filesystem holding ~/.cache/huggingface.
+# EXCLUDE takes space-separated globs and skips those files. Its use is a
+# compressed-tensors checkpoint whose BF16 PLE table you intend to replace with a
+# donor's FP8 one (see scripts/prepare-ct.sh): that table is one ~102 GB shard, so
+# skipping it turns a 183 GB download into 81 GB. Verify the donor first with
+# tools/verify_ple_donor.py, which needs no download at all.
+#
+# XET=1 turns the Xet backend back on. It is OFF by default because it stalled on some
+# Spark setups -- that is the reason for HF_HUB_DISABLE_XET below, not a speed judgement.
+# On a fast link the difference is large: --max-workers only parallelises across *files*,
+# so a checkpoint of a dozen large shards leaves most of a gigabit idle over plain HTTPS,
+# while Xet issues concurrent ranged reads *within* each file. Measured here on a DGX
+# Spark on gigabit fibre, pulling 81 GB of orcarouter/...-Uncensored-NVFP4:
+#
+#     plain HTTPS, 8 workers    14.7 MB/s   (117 Mbit/s)
+#     XET=1                    101   MB/s   (809 Mbit/s, ~86% of line rate) -- 13.4 min
+#
+# Caveat, and why it stays off by default: that run still ended in an httpx.ReadTimeout
+# after the last file finished. Every blob was complete and verified, but the exit code
+# was non-zero, so a wrapper that trusts it will think the download failed. Re-run to
+# confirm -- it is resumable and a completed download re-checks in seconds.
+# Xet-backed repos are the ones whose API tree entries carry an "xetHash".
+#
+# MAX_WORKERS is worth raising when the Hub, rather than your link, is the limit.
+# Check which it is: measure the NIC while the download runs
+# (/sys/class/net/<if>/statistics/rx_bytes), then run a few parallel streams from an
+# unrelated CDN. If the total goes well above what the download alone was getting,
+# there is headroom and more workers will use it; if it does not, the pipe is full and
+# more workers only add overhead.
+#
+# The default checkpoint needs ~140 GB free on the filesystem holding
+# ~/.cache/huggingface; check the model's own file list for others.
+#
+# Gated repos: run `hf auth login` once. The token lands in the HF cache, which is
+# mounted into the container, so it is picked up without exporting HF_TOKEN.
 set -euo pipefail
 
 MODEL="${MODEL:-RadixArk/Qwen3.8-Flash-Next-NVFP4}"
 IMAGE="${IMAGE:-qwen38-flash-dgx}"          # or the upstream image; only needs `hf`
 HF_CACHE="${HF_CACHE:-$HOME/.cache/huggingface}"
+EXCLUDE="${EXCLUDE:-}"
+MAX_WORKERS="${MAX_WORKERS:-8}"
+XET="${XET:-0}"
 mkdir -p "$HF_CACHE"
+
+# One --exclude per glob. Patterns must not contain spaces (filenames don't).
+EXCL_FLAGS=""
+for pat in $EXCLUDE; do EXCL_FLAGS="$EXCL_FLAGS --exclude '$pat'"; done
 
 # hf authenticates via HF_TOKEN (or the older HUGGING_FACE_HUB_TOKEN name).
 # docker -e NAME (no value) copies the host env var into the container.
@@ -19,17 +64,21 @@ if [ -n "${HF_TOKEN:-}" ]; then
   TOKEN_ARGS+=(-e HF_TOKEN)
 elif [ -n "${HUGGING_FACE_HUB_TOKEN:-}" ]; then
   TOKEN_ARGS+=(-e HUGGING_FACE_HUB_TOKEN -e HF_TOKEN="$HUGGING_FACE_HUB_TOKEN")
+elif [ -s "$HF_CACHE/token" ]; then
+  echo ">> using the token from $HF_CACHE/token (hf auth login)"
 else
-  echo ">> no HF_TOKEN in the environment; Hub will rate-limit unauthenticated downloads"
+  echo ">> no HF_TOKEN and no $HF_CACHE/token; Hub will rate-limit, and gated repos will 401"
 fi
 
-echo ">> downloading $MODEL into $HF_CACHE (resumable)"
-# HF_HUB_DISABLE_XET=1: the Xet backend stalled on some Spark setups; plain HTTPS
-# is reliable and saturates the link.
+echo ">> downloading $MODEL into $HF_CACHE (resumable, $MAX_WORKERS workers)${EXCLUDE:+, excluding: $EXCLUDE}"
+# HF_HUB_DISABLE_XET=1: the Xet backend stalled on some Spark setups; plain HTTPS is
+# reliable, but on a fast link it leaves most of it idle -- see XET=1 above.
+XET_ENV=(-e HF_HUB_DISABLE_XET=1)
+[ "$XET" = 1 ] && XET_ENV=(-e HF_HUB_DISABLE_XET=0 -e HF_XET_HIGH_PERFORMANCE=1)
 docker run --rm --name qwen38-dl \
-  -e HF_HOME=/hf -e HF_HUB_DISABLE_XET=1 \
+  -e HF_HOME=/hf "${XET_ENV[@]}" \
   "${TOKEN_ARGS[@]}" \
   -v "$HF_CACHE:/hf" --entrypoint bash "$IMAGE" \
-  -c "hf download '$MODEL' --max-workers 8"
+  -c "hf download '$MODEL' --max-workers $MAX_WORKERS$EXCL_FLAGS"
 
 echo ">> done. Verify with:  scripts/serve.sh"

--- a/scripts/download-weights.sh
+++ b/scripts/download-weights.sh
@@ -9,11 +9,12 @@
 #   MAX_WORKERS=24 scripts/download-weights.sh     # more parallel connections
 #   XET=1 scripts/download-weights.sh              # Xet backend (see the caution below)
 #
-# EXCLUDE takes space-separated globs and skips those files. Its use is a
-# compressed-tensors checkpoint whose BF16 PLE table you intend to replace with a
-# donor's FP8 one (see scripts/prepare-ct.sh): that table is one ~102 GB shard, so
-# skipping it turns a 183 GB download into 81 GB. Verify the donor first with
-# tools/verify_ple_donor.py, which needs no download at all.
+# EXCLUDE takes space-separated globs and skips those files -- for a checkpoint
+# where you already have an equivalent copy of one large shard, or do not intend to
+# serve it. On some checkpoints the PLE n-gram table alone is a ~102 GB shard, so
+# skipping one file can halve the download. Only skip a shard you can account for:
+# the index still names it, so whatever consumes the checkpoint has to be told
+# where those tensors live instead.
 #
 # XET=1 turns the Xet backend back on. It is OFF by default because it stalled on some
 # Spark setups -- that is the reason for HF_HUB_DISABLE_XET below, not a speed judgement.

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -32,6 +32,12 @@
 #   YARN=0            1 = YaRN rope scaling (factor 4) for CTX > 262144
 #   SEQS=8            max concurrent sequences. Do NOT leave this at 1-2 when measuring
 #                     throughput: requests queue silently and aggregate tok/s flatlines
+#   KV_CACHE_MEM=     bytes for the KV cache, as --kv-cache-memory-bytes. GPU_MEM is a fraction of
+#                     TOTAL device memory, so it also leaves out whatever was already resident;
+#                     vLLM prints the exact value it would accept at startup ("Replace
+#                     gpu_memory_utilization config with --kv-cache-memory=..."). On a Spark the
+#                     headroom it reports is also what the page cache uses for the PLE table, so
+#                     claiming it trades prefill for KV. Watch vllm:ple_mmap_gather_seconds_total
 #   GPU_MEM=0.80      fraction of the 128 GB pool for weights+KV. 0.85 buys ~2 GiB of KV but the
 #                     box drifted into swap after a day at it; 0.875 got OOM-killed on a 300k prefill
 #   MTP=2             speculative tokens from the model's MTP head (0 = off)
@@ -63,6 +69,7 @@ SEQS="${SEQS:-8}"
 GPU_MEM="${GPU_MEM:-0.80}"
 MTP="${MTP:-2}"
 KV_DTYPE="${KV_DTYPE:-auto}"
+KV_CACHE_MEM="${KV_CACHE_MEM:-}"
 PREWARM="${PREWARM:-0}"
 EXTRA="${EXTRA:-}"
 
@@ -169,7 +176,7 @@ docker run -d --name "$NAME" --restart unless-stopped \
     $PC_ARG --enable-chunked-prefill --max-num-batched-tokens 8192 \
     $CC \
     --no-enable-flashinfer-autotune \
-    --kv-cache-dtype "$KV_DTYPE" \
+    --kv-cache-dtype "$KV_DTYPE" ${KV_CACHE_MEM:+--kv-cache-memory-bytes "$KV_CACHE_MEM"} \
     "${OVR_ARGS[@]}" "${LOGARGS[@]}" $EXTRA \
     --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3 \
     "${SPEC[@]}"

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -32,6 +32,7 @@
 #   YARN=0            1 = YaRN rope scaling (factor 4) for CTX > 262144
 #   SEQS=8            max concurrent sequences. Do NOT leave this at 1-2 when measuring
 #                     throughput: requests queue silently and aggregate tok/s flatlines
+#   PROM_MULTIPROC=0  1 = engine-side metrics (vllm:ple_mmap_*) reach /metrics (opt-in; see PROM_ARGS below)
 #   KV_CACHE_MEM=     bytes for the KV cache, as --kv-cache-memory-bytes. GPU_MEM is a fraction of
 #                     TOTAL device memory, so it also leaves out whatever was already resident;
 #                     vLLM prints the exact value it would accept at startup ("Replace
@@ -70,6 +71,7 @@ GPU_MEM="${GPU_MEM:-0.80}"
 MTP="${MTP:-2}"
 KV_DTYPE="${KV_DTYPE:-auto}"
 KV_CACHE_MEM="${KV_CACHE_MEM:-}"
+PROM_MULTIPROC="${PROM_MULTIPROC:-0}"
 PREWARM="${PREWARM:-0}"
 EXTRA="${EXTRA:-}"
 
@@ -158,6 +160,17 @@ LOGARGS=(); [ "$LOG_REQUESTS" = 1 ] && { DETENV+=(-e VLLM_LOGGING_LEVEL=DEBUG); 
 PC_ARG=--no-enable-prefix-caching
 [ "$PREFIX_CACHE" = 1 ] && PC_ARG=--enable-prefix-caching
 
+# PROM_MULTIPROC=1 (opt-in): the vllm:ple_mmap_* counters (src/vllm_ple_mmap.py) live in the
+# EngineCore process. vLLM only puts prometheus_client into multiprocess mode for
+# api_server_count > 1, so with the single API server used here they would sit in
+# EngineCore's private registry and never reach /metrics. Setting
+# PROMETHEUS_MULTIPROC_DIR here makes /metrics aggregate every vLLM process; the tmpfs
+# is fresh per container, so no stale per-process files survive a restart.
+# Measured against a single-process /metrics: vLLM's own series keep their names and
+# labels, with no per-process pid label; the only loss is the *_created samples, which
+# prometheus_client does not export in multiprocess mode. That is why it is off
+# by default: it changes what existing dashboards see.
+PROM_ARGS=(); [ "$PROM_MULTIPROC" = 1 ] && PROM_ARGS=(--tmpfs /tmp/vllm-prometheus:rw,size=256m -e PROMETHEUS_MULTIPROC_DIR=/tmp/vllm-prometheus)
 docker rm -f "$NAME" >/dev/null 2>&1 || true
 # If docker run itself fails (port already bound, ...) do not leave a Created container behind.
 trap 'rc=$?; [ $rc -ne 0 ] && docker rm -f "$NAME" >/dev/null 2>&1; exit $rc' EXIT
@@ -165,6 +178,7 @@ trap 'rc=$?; [ $rc -ne 0 ] && docker rm -f "$NAME" >/dev/null 2>&1; exit $rc' EX
 docker run -d --name "$NAME" --restart unless-stopped \
   --gpus all --ipc=host --shm-size 16g -p "${PORT}:8000" \
   -v "$HF_CACHE:/hf" -e HF_HOME=/hf -e HF_HUB_OFFLINE=1 \
+  "${PROM_ARGS[@]}" \
   -e VLLM_PLE_MMAP=1 -e VLLM_PLE_MMAP_WORKERS="${WORKERS:-32}" -e VLLM_PLE_MMAP_PREWARM="$PREWARM" \
   -e VLLM_QSA_EXACT_TOPK="$EXACT_TOPK" "${DETENV[@]}" -e VLLM_FP8_PAD_M4="$PAD_M4" \
   -e VLLM_USE_FLASHINFER_SAMPLER=1 -e VLLM_ALLOW_LONG_MAX_MODEL_LEN="$ALLOW_LONG" \

--- a/src/vllm_ple_mmap.py
+++ b/src/vllm_ple_mmap.py
@@ -404,11 +404,12 @@ _STATS = {"calls": 0, "op_ms": 0.0, "gather_ms": 0.0, "rows": 0, "bytes": 0}
 # cost depends on runtime state (page-cache residency) rather than on config, so
 # it is exactly the thing worth graphing.
 #
-# These live in the EngineCore process, not the API server. That is fine: vLLM
-# sets PROMETHEUS_MULTIPROC_DIR and collects through prometheus_client's
-# MultiProcessCollector, so counters registered here are aggregated into the
-# frontend's /metrics. They are created lazily on first use, because the env var
-# must be set before the first metric is constructed.
+# These live in the EngineCore process, not the API server, so they only reach the
+# frontend's /metrics when prometheus_client runs in multiprocess mode: the API
+# server's MultiProcessCollector then aggregates what every process writes under
+# PROMETHEUS_MULTIPROC_DIR. vLLM only turns that on for api_server_count > 1;
+# scripts/serve.sh sets it when PROM_MULTIPROC=1 (opt-in). They are created lazily on first use,
+# because the env var must be set before the first metric is constructed.
 #
 # Derived views worth having:
 #   rate(vllm:ple_mmap_op_seconds_total[5m])
@@ -430,6 +431,15 @@ def _prom() -> dict[str, object] | None:
     _PROM_TRIED = True
     if os.environ.get("VLLM_PLE_MMAP_PROMETHEUS", "1").lower() in ("0", "false", "no"):
         return None
+    if not os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        # The default. vLLM only enables multiprocess metrics for api_server_count > 1,
+        # and exporting these costs vLLM its *_created samples, so it is opt-in: say how
+        # to turn it on rather than warn about the expected configuration.
+        logger.info(
+            "PLE mmap: PROMETHEUS_MULTIPROC_DIR is unset, so the vllm:ple_mmap_* counters "
+            "stay in this process and will not appear on /metrics while the engine runs "
+            "in its own process. scripts/serve.sh exports them with PROM_MULTIPROC=1."
+        )
     try:
         from prometheus_client import Counter
 

--- a/src/vllm_ple_mmap.py
+++ b/src/vllm_ple_mmap.py
@@ -35,6 +35,7 @@ Knobs (env):
   VLLM_PLE_MMAP_WORKERS=32   gather threads (page faults overlap across threads)
   VLLM_PLE_MMAP_CHUNK=2048   rows per gather task
   VLLM_PLE_MMAP_MADVISE=random  madvise on the shard mmaps: random (default, no readahead) or normal
+  VLLM_PLE_MMAP_PROMETHEUS=1 0 = do not register the vllm:ple_mmap_* counters
   VLLM_PLE_MMAP_PREWARM=0    1 = stream the whole table once at load to fill the
                              page cache with whatever memory is free (harmless,
                              evictable; ~10 s at 4.7 GB/s)
@@ -169,9 +170,12 @@ class MmapPleTable:
         try:
             return self._gather(ids)
         finally:
-            _STATS["gather_ms"] += (_time.perf_counter() - t0) * 1e3
-            _STATS["rows"] += int(np.asarray(ids).size)
-            _STATS["bytes"] += int(np.asarray(ids).size) * self.row_bytes
+            dt = _time.perf_counter() - t0
+            n = int(np.asarray(ids).size)
+            _STATS["gather_ms"] += dt * 1e3
+            _STATS["rows"] += n
+            _STATS["bytes"] += n * self.row_bytes
+            _prom_add(gather_s=dt, rows=n, bytes=n * self.row_bytes)
 
     def _gather(self, ids: np.ndarray) -> np.ndarray:
         ids = np.ascontiguousarray(ids, dtype=np.int64).reshape(-1)
@@ -392,6 +396,82 @@ _OP_NAME = "ple_mmap_lookup"
 # Aggregate gather-overhead stats, logged every VLLM_PLE_MMAP_STATS_SEC seconds
 # (0 = off). op_ms covers hashing + gather + H2D; gather_ms just the disk reads.
 _STATS = {"calls": 0, "op_ms": 0.0, "gather_ms": 0.0, "rows": 0, "bytes": 0}
+
+# The same numbers as monotonic Prometheus counters, so the table's behaviour is
+# visible on a dashboard instead of only in the log line below (which is windowed,
+# reset every period, and destroyed with the container). Nothing else in this
+# recipe exposes how the mmapped table is coping: it is the one component whose
+# cost depends on runtime state (page-cache residency) rather than on config, so
+# it is exactly the thing worth graphing.
+#
+# These live in the EngineCore process, not the API server. That is fine: vLLM
+# sets PROMETHEUS_MULTIPROC_DIR and collects through prometheus_client's
+# MultiProcessCollector, so counters registered here are aggregated into the
+# frontend's /metrics. They are created lazily on first use, because the env var
+# must be set before the first metric is constructed.
+#
+# Derived views worth having:
+#   rate(vllm:ple_mmap_op_seconds_total[5m])
+#     / rate(vllm:ple_mmap_lookup_ops_total[5m])      mean seconds per lookup
+#   rate(vllm:ple_mmap_gather_seconds_total[5m])
+#     / rate(vllm:ple_mmap_op_seconds_total[5m])      fraction of the op spent on disk
+#   rate(vllm:ple_mmap_bytes_total[5m])               NVMe read bandwidth from the table
+# The second one is the page-cache health signal: it climbs as the cache is
+# squeezed and falls as the hot region settles in.
+_PROM: dict[str, object] | None = None
+_PROM_TRIED = False
+
+
+def _prom() -> dict[str, object] | None:
+    """Prometheus counters, or None if unavailable. Never raises, tried once."""
+    global _PROM, _PROM_TRIED
+    if _PROM_TRIED:
+        return _PROM
+    _PROM_TRIED = True
+    if os.environ.get("VLLM_PLE_MMAP_PROMETHEUS", "1").lower() in ("0", "false", "no"):
+        return None
+    try:
+        from prometheus_client import Counter
+
+        _PROM = {
+            "ops": Counter(
+                "vllm:ple_mmap_lookup_ops_total",
+                "PLE mmap lookups (hash + gather + H2D) executed.",
+            ),
+            "op_s": Counter(
+                "vllm:ple_mmap_op_seconds_total",
+                "Cumulative seconds in the PLE mmap lookup op.",
+            ),
+            "gather_s": Counter(
+                "vllm:ple_mmap_gather_seconds_total",
+                "Cumulative seconds in the PLE mmap row gather (the disk reads).",
+            ),
+            "rows": Counter(
+                "vllm:ple_mmap_rows_total",
+                "Rows gathered from the mmapped PLE table.",
+            ),
+            "bytes": Counter(
+                "vllm:ple_mmap_bytes_total",
+                "Bytes read from the mmapped PLE table (page cache or NVMe).",
+            ),
+        }
+        logger.info("PLE mmap: Prometheus counters registered")
+    except Exception as exc:  # pragma: no cover - metrics must never break serving
+        logger.warning("PLE mmap: Prometheus counters unavailable: %s", exc)
+        _PROM = None
+    return _PROM
+
+
+def _prom_add(**kw: float) -> None:
+    """Best-effort counter increment; a metrics failure must not fail a request."""
+    p = _prom()
+    if not p:
+        return
+    try:
+        for key, value in kw.items():
+            p[key].inc(value)  # type: ignore[attr-defined]
+    except Exception:  # pragma: no cover
+        pass
 _STATS_LAST = [0.0]
 _STATS_SEC = _env_int("VLLM_PLE_MMAP_STATS_SEC", 30)
 
@@ -432,8 +512,10 @@ def _lookup_impl(
         None, input_ids, query_start_loc, ngram_context
     )
     output[: result.shape[0]].copy_(result.to(output.dtype))
+    dt = _time.perf_counter() - t0
     _STATS["calls"] += 1
-    _STATS["op_ms"] += (_time.perf_counter() - t0) * 1e3
+    _STATS["op_ms"] += dt * 1e3
+    _prom_add(ops=1, op_s=dt)
     _stats_log()
 
 
@@ -458,8 +540,10 @@ def _lookup_ids_impl(ngram_ids: torch.Tensor, output: torch.Tensor, layer_name: 
     layer = _REGISTRY[layer_name]
     rows = layer.ngram_embedding(ngram_ids)  # (N, heads, head_dim), table dtype (or zeros)
     output.copy_(rows.reshape(rows.shape[0], -1).to(output.dtype))
+    dt = _time.perf_counter() - t0
     _STATS["calls"] += 1
-    _STATS["op_ms"] += (_time.perf_counter() - t0) * 1e3
+    _STATS["op_ms"] += dt * 1e3
+    _prom_add(ops=1, op_s=dt)
     _stats_log()
 
 


### PR DESCRIPTION
The infrastructure half of #13, which you green-lit. No new mode, no new checkpoint
family — these three are independent of that work and help every existing mode. The
`MODE=ct` support follows separately, with numbers, as you asked.

Rebased onto current `main` (c578815), so it sits on top of `./flash` and
`Dockerfile.v0.29`. Measured on a DGX Spark (GB10, 128 GB).

## 1. `scripts/download-weights.sh`: `EXCLUDE`, `MAX_WORKERS`, `XET`

All three default to today's behaviour.

**`XET=1`** re-enables the Xet backend. The blanket `HF_HUB_DISABLE_XET=1` is a
stability choice, and it stays the default — but on a fast link it is expensive,
because `--max-workers` only parallelises across *files* and these checkpoints are a
dozen large shards, so most of a gigabit sits idle. Pulling 81 GB on gigabit fibre:

| | rate | 81 GB takes |
|---|---|---|
| plain HTTPS, 8 workers (default) | 14.7 MB/s (117 Mbit/s) | ~92 min |
| `XET=1` | **101 MB/s (809 Mbit/s)** | **13.4 min** |

I confirmed the Hub rather than the link was the limit before changing anything:
measuring the NIC while the download ran, then adding parallel streams from an unrelated
CDN, took the box to 203 Mbit/s combined — headroom the one-file-per-worker pattern
couldn't use.

**It stays off by default even so**, and not only for your original reason: that run
ended in an `httpx.ReadTimeout` *after* the last file completed. Every blob was intact,
but the exit code was non-zero, so anything that trusts it will conclude the download
failed.

**`EXCLUDE`** takes space-separated globs, for a checkpoint where you already hold an
equivalent copy of a large shard. The docs say plainly that the index still names a
skipped file, so whatever consumes the checkpoint has to be told where those tensors
live instead.

**Also:** the "no HF_TOKEN" warning fired even when `hf auth login` had written a token
into the cache — which is mounted into the container and picked up fine. It now reports
that case, and says plainly that gated repos will 401 when there is genuinely no
credential.

Works through `./flash` unchanged: `setup` invokes the script as `env IMAGE=… MODEL=…
HF_CACHE=… scripts/download-weights.sh`, which adds to the inherited environment, so
the knobs pass through from the shell, a profile, or a `K=V` argument.

## 2. `vllm:ple_mmap_*` Prometheus counters (export is opt-in)

The mmapped table is the one component in this recipe whose cost depends on runtime
state rather than configuration — how much of its 47.7 GiB the page cache holds decides
prefill speed, and that moves as the KV pool, the request mix and the OS pull on the
same unified memory. The only visibility today is a log line every 30 s: windowed,
reset each period, and destroyed by the `docker rm -f` that `serve.sh` opens with.

Five monotonic counters alongside that log line, which is unchanged:

```
vllm:ple_mmap_lookup_ops_total
vllm:ple_mmap_op_seconds_total
vllm:ple_mmap_gather_seconds_total
vllm:ple_mmap_rows_total
vllm:ple_mmap_bytes_total
```

`rate(gather_seconds) / rate(op_seconds)` is the page-cache health signal — the share of
each lookup spent waiting on disk.

**Both op paths are covered**: `vllm::ple_mmap_lookup` (preview) and
`vllm::ple_mmap_lookup_ids` (the v0.29 layout from 6c3e7e1). The v0.29 op updates
`_STATS` on its own, so hooking only the first would have left the v0.29 counters at
zero while the log line showed traffic. The row counters live in
`MmapPleTable.gather`, which both layouts reach through the same
`_MmapNgramEmbedding` placeholder.

**Getting them onto `/metrics` needed one more change, which I only found by booting
it.** They register in the EngineCore process, so they reach `/metrics` only when
prometheus_client runs in multiprocess mode — and vLLM turns that on only for
`api_server_count > 1` (`entrypoints/cli/serve.py`). With the single API server this
recipe runs, `PROMETHEUS_MULTIPROC_DIR` stays unset in every process and anything
registered in EngineCore is silently never exported: the log said the counters were
registered, and `/metrics` had none of them. With `PROM_MULTIPROC=1`, `scripts/serve.sh` sets the
variable itself on a per-container tmpfs. It is **opt-in** — off by default — because it
changes vLLM's own exported series, as measured below; with it off, the module logs one
info line saying how to turn it on.

**What that costs anyone already graphing vLLM**, measured by diffing the complete
`/metrics` before and after on a live server: vLLM's other 71 metric families are
exported with identical label sets and no per-process `pid` label. The only loss is the
35 `*_created` families, because prometheus_client does not export created timestamps in
multiprocess mode. That is the reason it is opt-in: nothing
changes for anyone's existing dashboards unless they ask for the counters.

Counters are created lazily, since that variable must be set before the first metric is
constructed, and every path is wrapped so a metrics failure can never fail a request.
`VLLM_PLE_MMAP_PROMETHEUS=0` opts out.

## 3. `KV_CACHE_MEM` → `--kv-cache-memory-bytes`

`gpu_memory_utilization` is a fraction of **total** device memory:

```python
requested_memory = math.ceil(init_snapshot.total_memory * cache_config.gpu_memory_utilization)
```

So anything already resident when the engine starts is silently deducted from KV rather
than from the reservation. On my box that was 6.6 GiB, and vLLM itself reported 33.19 GiB
claimable against the 16.06 GiB the ratio allowed. The ratio also cannot express "put
freed weight memory into page cache rather than KV" — the arena is sized independently
of the weights, so shrinking them turns the slack into KV whether you wanted that or not.

On a Spark this is **a trade, not free memory**: the headroom vLLM reports is the same
memory the page cache uses for the PLE table. The counters above are how you tell which
side is winning.

It passes the canonical `--kv-cache-memory-bytes`. vLLM's own startup hint spells it
`--kv-cache-memory`, which works today only through argparse prefix matching and would
break the moment another `--kv-cache-memory-*` flag appears. Profiles and `K=V`
overrides in `./flash` pass it straight through.

## Testing

- **Counters, multiprocess path** — an integration test drives all three hook sites
  (row gather, preview op, v0.29 op) from a spawned process and collects through vLLM's
  `get_prometheus_registry()`: both op paths counted, rows/bytes exact, both timings
  recorded. `src/test_ple_mmap_cpu.py` still passes. A second check with `PROMETHEUS_MULTIPROC_DIR`
  unset (the default) confirms they still register and log how to enable export. The
  first test alone was *not* enough:
  it enabled multiprocess mode explicitly, which single-server vLLM never does. The live
  boot is what caught it.
- **The flag** — against the real `vllm serve` parser (`make_arg_parser`),
  `--kv-cache-memory-bytes` parses to `kv_cache_memory_bytes`. It is registered, with no
  alias, in vLLM 0.28.0 and in a current main nightly. A preview image built from this
  branch and booted with `KV_CACHE_MEM=12884901888` logged `reserved 12.0 GiB memory for
  KV Cache as specified by kv_cache_memory_bytes config and skipped memory profiling`,
  and sized the pool at 424,354 tokens.
- **Live counters** — booted with `PROM_MULTIPROC=1` and sent three short greedy requests. All
  five counters appear on the live `/metrics` and increase with the requests: 50 lookups,
  2,536 rows, 405,760 bytes (exactly 160 per row, the fp8 table's row width), 0.64 s in
  the op of which 0.48 s in the row gather — a mean lookup of 12.8 ms, 75% of it
  gathering rows. With it off — the default, and the configuration of the first boot —
  `/metrics` is vLLM's usual single-process output and the counters do not appear.
- **Download knobs** — they are what pulled the 81 GB above.
- **Not verified:** a v0.29.0 image was not booted. The counters reach its op path by
  construction and the integration test drives that function directly, and the
  Prometheus multiproc setup is identical in the 0.28.0 and nightly images checked —
  but I have not observed them on a running v0.29 server.

Happy to split this into three PRs if you would rather review them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
