### PR TITLE
Preserve quoted Qwen tool markers and following final answers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Qwen3.8-Flash-Next on a single DGX Spark / GB10, via vLLM.
 #
 # Starts from the official Qwen3.8-Flash-Next vLLM image and layers a handful of
-# patches on it. Every one of them is a no-op unless its runtime flag is set, so
-# the image still behaves like upstream with the flags off:
+# patches on it. Performance options are gated by runtime flags; correctness
+# fixes are enabled as listed below:
 #
 #   1. PLE table served from disk via mmap            (VLLM_PLE_MMAP=1)      — the one that makes it fit
 #   2. GB10 FLA fixes                                  (always on, harmless elsewhere)
@@ -14,6 +14,7 @@
 #   8. Deterministic persistent_topk kernel           (VLLM_QSA_DET_TOPK=1) — replaces 5 at no prefill cost
 #   9. M%4 padding for the blockwise-fp8 GEMM         (VLLM_FP8_PAD_M4=1)   — hybrid mode with prefix caching OFF
 #  10. Reduced draft vocabulary for the MTP drafter    (VLLM_MTP_DRAFT_VOCAB=<ids.npy>) — +20% decode, same tournament score
+#  11. Lossless malformed Qwen tool preambles        (always on for the qwen3 parser)
 #
 #   docker build -t qwen38-flash-dgx .
 #
@@ -148,3 +149,9 @@ RUN python3 /tmp/fp8_m4pad_patch.py && rm /tmp/fp8_m4pad_patch.py \
 COPY src/patch_mtp_draft_vocab.py /tmp/patch_mtp_draft_vocab.py
 COPY src/draft_vocab_65536.npy /opt/llm/draft_vocab_65536.npy
 RUN python3 /tmp/patch_mtp_draft_vocab.py ${SP}/vllm/models/qwen3_8_flash_next/nvidia/mtp.py && rm /tmp/patch_mtp_draft_vocab.py
+
+# --- 11. Preserve quoted/malformed Qwen tool markers in reasoning and content ---
+# Confirm a tool preamble before switching output channels. Shared by both bases.
+COPY src/patches/qwen-tool-preamble.patch /tmp/qwen-tool-preamble.patch
+RUN cd ${SP} && patch --batch --forward --fuzz=0 -p1 < /tmp/qwen-tool-preamble.patch \
+ && rm /tmp/qwen-tool-preamble.patch

--- a/Dockerfile.v0.29
+++ b/Dockerfile.v0.29
@@ -1,7 +1,7 @@
 # Qwen3.8-Flash-Next on a DGX Spark — vLLM v0.29.0 base (the official release that ships the model as
 # `vllm/models/qwen4_exp`). Same patch set as the preview-image Dockerfile, re-targeted:
 #   1 PLE mmap, 2 GB10 FLA fixes, 4 prefix-caching block_size fix, 5 exact top-k, 6 hybrid mode,
-#   8 deterministic top-k kernel, 10 reduced draft vocabulary.
+#   8 deterministic top-k kernel, 10 reduced draft vocabulary, 11 Qwen tool preamble fix.
 # Not needed here: 3 (vllm#50729 is in) and 9 (vllm#52775 is in). Not ported yet: 7 (fp8 KV cache).
 #
 #   docker build -f Dockerfile.v0.29 -t qwen38-flash-dgx:v0.29 .
@@ -66,3 +66,9 @@ RUN cd /opt/llm/kernel-det/src && DET_BUILD_DIR=/opt/llm/kernel-det/build DET_AR
 COPY src/patch_mtp_draft_vocab.py /tmp/patch_mtp_draft_vocab.py
 COPY src/draft_vocab_65536.npy /opt/llm/draft_vocab_65536.npy
 RUN python3 /tmp/patch_mtp_draft_vocab.py ${PKG}/mtp.py && rm /tmp/patch_mtp_draft_vocab.py
+
+# --- 11. Preserve quoted/malformed Qwen tool markers in reasoning and content ---
+# Confirm a tool preamble before switching output channels. Shared by both bases.
+COPY src/patches/qwen-tool-preamble.patch /tmp/qwen-tool-preamble.patch
+RUN cd ${SP} && patch --batch --forward --fuzz=0 -p1 < /tmp/qwen-tool-preamble.patch \
+ && rm /tmp/qwen-tool-preamble.patch

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ be overridden on the command line (`./flash serve default MTP=3 PORT=18301`). `.
 The same thing by hand, unchanged and still supported (everything `flash` does is these scripts):
 
 ```bash
-docker build -t qwen38-flash-dgx .            # ~1 min: official vLLM image + the 10 patches below
+docker build -t qwen38-flash-dgx .            # ~1 min: official vLLM image + the 11 patches below
 scripts/download-weights.sh                   # RadixArk NVFP4 checkpoint, ~126 GiB, resumable (one-time)
 scripts/prepare-hybrid.sh                     # recommended: fp8 side layers, +20% decode, same quality (~10 min, one-time)
 MODE=hybrid YARN=1 CTX=500000 scripts/serve.sh   # the recipe our own box runs; 500k context, ~13 min to load
@@ -61,6 +61,27 @@ Everything below is the long version: what was broken on GB10, what was fixed, a
 > [@jschmied](https://github.com/jschmied) — see
 > [issue #1](https://github.com/blazux/qwen3.8-Flash-DGX/issues/1) and their
 > [write-up](https://github.com/jschmied/qwen38-flash-next-gb10).
+
+## Quoted tool markers
+
+Both image recipes include a parser fix for literal or malformed `<tool_call>`
+markers in Qwen reasoning and ordinary text. Previously, quoting that marker could
+switch the parser into a tool preamble and discard subsequent text, including a
+final answer after `</think>`. The parser now buffers the marker and preserves it as text when ordinary prose
+follows, while recognizing a function-header prefix (`<function=`) as a tool call.
+Valid calls and existing empty-wrapper/end-of-stream handling are retained.
+The fix is enabled for the `qwen3` parser; derived parser configurations retain
+their existing behavior.
+
+The regression patch extends vLLM's existing Qwen parser tests. To run it from a
+matching vLLM source checkout with its test dependencies installed (using absolute
+paths to this repository's patch files):
+
+```bash
+patch --batch --forward --fuzz=0 -p1 < /path/to/qwen3.8-Flash-DGX/src/patches/qwen-tool-preamble.patch
+patch --batch --forward --fuzz=0 -p1 < /path/to/qwen3.8-Flash-DGX/src/patches/qwen-tool-preamble-tests.patch
+.venv/bin/python -m pytest tests/parser/engine -q
+```
 
 ## Update 2026-09-11 — what changed
 

--- a/src/patches/qwen-tool-preamble-tests.patch
+++ b/src/patches/qwen-tool-preamble-tests.patch
@@ -1,0 +1,125 @@
+diff --git a/tests/parser/engine/test_qwen3_reasoning.py b/tests/parser/engine/test_qwen3_reasoning.py
+--- a/tests/parser/engine/test_qwen3_reasoning.py
++++ b/tests/parser/engine/test_qwen3_reasoning.py
+@@ -16,11 +16,13 @@
+ from tests.parser.engine.conftest import make_mock_tokenizer
+ from tests.parser.engine.streaming_helpers import simulate_reasoning_streaming
+ from vllm.parser.abstract_parser import DelegatingParser
++from vllm.parser.engine.events import EventType
+ from vllm.parser.engine.parser_engine_config import ParserState
+ from vllm.parser.engine.registered_adapters import (
+     Qwen3ParserReasoningAdapter,
+     Qwen3ParserToolAdapter,
+ )
++from vllm.parser.engine.streaming_parser_engine import StreamingParserEngine
+ from vllm.parser.qwen3 import Qwen3Parser, qwen3_config
+ 
+ _THINK_START_ID = 50
+@@ -56,7 +58,107 @@
+     return Qwen3Parser(mock_tokenizer)
+ 
+ 
++@pytest.mark.parametrize("thinking", [True, False])
++@pytest.mark.parametrize("chunk_size", [1, 7, 1000])
++def test_malformed_tool_preamble_is_lossless_across_chunks(thinking, chunk_size):
++    text = "Quoted `<tool_call>` prose </tool_call> still visible."
++    engine = StreamingParserEngine(qwen3_config(thinking=thinking), None)
++    events = []
++    for offset in range(0, len(text), chunk_size):
++        events.extend(engine.feed(text[offset : offset + chunk_size], []))
++    events.extend(engine.finish())
++    kind = EventType.REASONING_CHUNK if thinking else EventType.TEXT_CHUNK
++    assert "".join(e.value for e in events if e.type == kind) == text
++    assert not any(e.type == EventType.TOOL_CALL_START for e in events)
++
++
++def test_malformed_special_token_then_real_tool_preserves_tool_index(mock_tokenizer):
++    engine = StreamingParserEngine(qwen3_config(), mock_tokenizer)
++    events = engine.feed("<tool_call>", [_TOOL_CALL_ID])
++    assert not events
++    events += engine.feed("` quoted marker. ", [])
++    events += engine.feed("<tool_call>", [_TOOL_CALL_ID])
++    events += engine.feed("\n<function=bash><parameter=cmd>pwd</parameter>", [])
++    events += engine.feed("</function></tool_call>", [_TOOL_CALL_END_ID])
++    events += engine.finish()
++    assert (
++        "".join(e.value for e in events if e.type == EventType.REASONING_CHUNK)
++        == "<tool_call>` quoted marker. "
++    )
++    starts = [e for e in events if e.type == EventType.TOOL_CALL_START]
++    assert len(starts) == 1
++    assert starts[0].tool_index == 0
++    assert "".join(e.value for e in events if e.type == EventType.TOOL_NAME) == "bash"
++
++
++@pytest.mark.parametrize("chunk_size", [1, 2, 7, 64, 1000])
++@pytest.mark.parametrize(
++    "reasoning",
++    [
++        "The literal marker is `<tool_call>` in prose.",
++        "The wrapper is `<tool_call>quoted</tool_call>` in prose.",
++    ],
++)
++def test_quoted_tool_marker_preserves_following_final_answer(reasoning, chunk_size):
++    """A malformed wrapper must not swallow the real reasoning end or answer."""
++    text = reasoning + "</think>The answer is 42."
++    engine = StreamingParserEngine(qwen3_config(), None)
++    events = []
++    for offset in range(0, len(text), chunk_size):
++        events.extend(engine.feed(text[offset : offset + chunk_size], []))
++    events.extend(engine.finish())
++    assert (
++        "".join(e.value for e in events if e.type == EventType.REASONING_CHUNK)
++        == reasoning
++    )
++    assert (
++        "".join(e.value for e in events if e.type == EventType.TEXT_CHUNK)
++        == "The answer is 42."
++    )
++    assert not any(e.type == EventType.TOOL_CALL_START for e in events)
++
++
++def test_quoted_special_token_preserves_following_final_answer(mock_tokenizer):
++    engine = StreamingParserEngine(qwen3_config(), mock_tokenizer)
++    events = engine.feed("The literal marker is `", [])
++    events += engine.feed("<tool_call>", [_TOOL_CALL_ID])
++    events += engine.feed("` in prose.", [])
++    events += engine.feed("</think>", [_THINK_END_ID])
++    events += engine.feed("The answer is 42.", [])
++    events += engine.finish()
++    assert (
++        "".join(e.value for e in events if e.type == EventType.REASONING_CHUNK)
++        == "The literal marker is `<tool_call>` in prose."
++    )
++    assert (
++        "".join(e.value for e in events if e.type == EventType.TEXT_CHUNK)
++        == "The answer is 42."
++    )
++    assert not any(e.type == EventType.TOOL_CALL_START for e in events)
++
++
+ class TestNonStreaming:
++    def test_quoted_tool_marker_preserves_following_final_answer(self, parser):
++        reasoning = "The literal marker is `<tool_call>` in prose."
++        actual_reasoning, content = parser.extract_reasoning(
++            reasoning + "</think>The answer is 42.", None
++        )
++        assert actual_reasoning == reasoning
++        assert content == "The answer is 42."
++
++    @pytest.mark.parametrize(
++        "candidate",
++        [
++            "<tool_call>` ordinary prose continues",
++            "<tool_call>quoted text</tool_call>",
++        ],
++    )
++    def test_malformed_tool_preamble_preserves_reasoning(self, parser, candidate):
++        text = "The literal marker is `" + candidate
++        reasoning, content = parser.extract_reasoning(text, None)
++        assert reasoning == text
++        assert content is None
++
+     def test_reasoning_then_content(self, parser):
+         text = "<think>Let me analyze.</think>The answer is 42."
+         reasoning, content = parser.extract_reasoning(text, None)

--- a/src/patches/qwen-tool-preamble.patch
+++ b/src/patches/qwen-tool-preamble.patch
@@ -1,0 +1,163 @@
+diff --git a/vllm/parser/engine/parser_engine_config.py b/vllm/parser/engine/parser_engine_config.py
+index 4799604..164aa55 100644
+--- a/vllm/parser/engine/parser_engine_config.py
++++ b/vllm/parser/engine/parser_engine_config.py
+@@ -100,6 +100,9 @@ class ParserEngineConfig:
+     # Reject tool calls whose names are absent from the request tools.
+     validate_tool_names: bool = False
+ 
++    # Delay a tool wrapper until its whitespace-only preamble reaches TOOL_NAME.
++    validate_tool_preamble: bool = False
++
+     @cached_property
+     def terminal_defs(self):
+         from vllm.parser.engine.incremental_lexer import terminals_from_literals
+diff --git a/vllm/parser/engine/streaming_parser_engine.py b/vllm/parser/engine/streaming_parser_engine.py
+index ec21b05..d42f57e 100644
+--- a/vllm/parser/engine/streaming_parser_engine.py
++++ b/vllm/parser/engine/streaming_parser_engine.py
+@@ -207,6 +207,9 @@ class StreamingParserEngine:
+         self._message_header_buffer = ""
+         self._message_header_token_count = 0
+         self._in_skipped_tool_span = False
++        self._pending_tool_start: tuple[str, str, int] | None = None
++        self._tool_preamble_buffer = ""
++        self._tool_preamble_token_count = 0
+         self._reset_args_state()
+ 
+     def feed(
+@@ -284,6 +287,8 @@ class StreamingParserEngine:
+ 
+         events.extend(self._process_lex_tokens(self._lexer.flush()))
+ 
++        events.extend(self._confirm_tool_preamble())
++
+         if self._args_buffer:
+             events.append(
+                 SemanticEvent(
+@@ -359,8 +364,28 @@ class StreamingParserEngine:
+     )
+ 
+     def _on_terminal(
+-        self, terminal: str, value: str, token_count: int = 0
++        self,
++        terminal: str,
++        value: str,
++        token_count: int = 0,
++        *,
++        confirmed_tool_start: bool = False,
+     ) -> list[SemanticEvent]:
++        if self._pending_tool_start is not None:
++            next_transition = self.config.transitions.get(
++                (ParserState.TOOL_PREAMBLE, terminal)
++            )
++            if next_transition is not None and next_transition.next_state in (
++                ParserState.TOOL_NAME,
++                ParserState.CONTENT,
++            ):
++                events = self._confirm_tool_preamble()
++                events.extend(self._on_terminal(terminal, value, token_count))
++                return events
++            events = self._flush_tool_preamble()
++            events.extend(self._on_terminal(terminal, value, token_count))
++            return events
++
+         key = (self.state, terminal)
+         transition = self.config.transitions.get(key)
+ 
+@@ -372,6 +397,15 @@ class StreamingParserEngine:
+                 self._in_skipped_tool_span = False
+             return self._emit_for_state(value, token_count)
+ 
++        if (
++            self.config.validate_tool_preamble
++            and not confirmed_tool_start
++            and self.state in (ParserState.CONTENT, ParserState.REASONING)
++            and transition.next_state == ParserState.TOOL_PREAMBLE
++        ):
++            self._pending_tool_start = (terminal, value, token_count)
++            return []
++
+         if self.skip_tool_parsing and terminal in self._tool_terminals:
+             # Inkling reuses one terminal for tool, text, and reasoning exits.
+             # Outside a forwarded tool span, apply its normal transition.
+@@ -430,6 +464,26 @@ class StreamingParserEngine:
+         return self._apply_transition(transition, value, token_count)
+ 
+     def _emit_for_state(self, text: str, token_count: int = 0) -> list[SemanticEvent]:
++        if self._pending_tool_start is not None:
++            self._tool_preamble_buffer += text
++            self._tool_preamble_token_count += token_count
++            if text.strip():
++                candidate = self._tool_preamble_buffer.lstrip()
++                for (state, terminal), tr in self.config.transitions.items():
++                    if (
++                        state == ParserState.TOOL_PREAMBLE
++                        and tr.next_state == ParserState.TOOL_NAME
++                        and (literal := self.config.terminals.get(terminal))
++                        and any(
++                            value.startswith(candidate)
++                            for value in (
++                                (literal,) if isinstance(literal, str) else literal
++                            )
++                        )
++                    ):
++                        return []
++                return self._flush_tool_preamble()
++            return []
+         if self.state == ParserState.MESSAGE_HEADER:
+             self._message_header_buffer += text
+             self._message_header_token_count += token_count
+@@ -457,6 +511,30 @@ class StreamingParserEngine:
+             ]
+         return []
+ 
++    def _flush_tool_preamble(self) -> list[SemanticEvent]:
++        if self._pending_tool_start is None:
++            return []
++        _, opener, opener_count = self._pending_tool_start
++        text = opener + self._tool_preamble_buffer
++        count = opener_count + self._tool_preamble_token_count
++        self._pending_tool_start = None
++        self._tool_preamble_buffer = ""
++        self._tool_preamble_token_count = 0
++        return self._emit_for_state(text, count)
++
++    def _confirm_tool_preamble(self) -> list[SemanticEvent]:
++        if self._pending_tool_start is None:
++            return []
++        opener = self._pending_tool_start
++        text = self._tool_preamble_buffer
++        count = self._tool_preamble_token_count
++        self._pending_tool_start = None
++        self._tool_preamble_buffer = ""
++        self._tool_preamble_token_count = 0
++        events = self._on_terminal(*opener, confirmed_tool_start=True)
++        events.extend(self._emit_for_state(text, count))
++        return events
++
+     def _on_content(self, text: str, token_count: int = 0) -> list[SemanticEvent]:
+         if not text:
+             return []
+diff --git a/vllm/parser/nemotron_v3.py b/vllm/parser/nemotron_v3.py
+index c8b75a2..2141c98 100644
+--- a/vllm/parser/nemotron_v3.py
++++ b/vllm/parser/nemotron_v3.py
+@@ -37,4 +37,5 @@ def nemotron_v3_config(thinking: bool = True) -> ParserEngineConfig:
+         name="nemotron_v3",
++        validate_tool_preamble=False,
+         strip_trailing_reasoning_whitespace=True,
+     )
+ 
+diff --git a/vllm/parser/qwen3.py b/vllm/parser/qwen3.py
+index 8edf42e..fd40925 100644
+--- a/vllm/parser/qwen3.py
++++ b/vllm/parser/qwen3.py
+@@ -198,6 +198,7 @@ def qwen3_config(
+         stream_arg_deltas=True,
+         strip_trailing_reasoning_whitespace=False,
+         tool_args_json=False,
++        validate_tool_preamble=name == "qwen3",
+     )
+ 
+ 


### PR DESCRIPTION
## Summary

Preserve literal `<tool_call>` markers and the text that follows them in Qwen reasoning and ordinary prose, including final answers after `</think>`. Apply the parser fix to both the preview and v0.29 image recipes.

## Why

The parser previously entered a tool preamble as soon as it saw the opener, which could discard quoted text and the following answer. It now buffers a potential opener until a function-header prefix confirms a tool call, or ordinary prose identifies the marker as literal text.

Valid calls retain their indexes and arguments. The fix is enabled for the `qwen3` configuration; derived configurations, including Nemotron, retain their existing behavior. Existing empty-wrapper and end-of-stream behavior is preserved. This remains separate from sampler/EOS policy and adds no launcher knob.

The conflict with current `main` is resolved by retaining its block-FP8 MTP patches and placing this parser fix after them as patch 12. The runtime and regression patches are byte-identical to the original PR head. Upstream report: https://github.com/vllm-project/vllm/issues/56658. Upstream code PR: https://github.com/vllm-project/vllm/pull/56661.

## Validation

Reran isolated CPU-only validation on 2026-09-15, using the installed parsers and adapters in the official images and upstream mock-tokenizer fixtures:

| Base | Before | After |
| --- | --- | --- |
| v0.29.0 | 3,801 passed / 21 failed | 3,822 passed / 0 failed |
| Qwen preview | 3,794 passed / 28 failed | 3,815 passed / 7 failed |

The same 21 regression cases fail before and pass after on both images. No previously passing test regresses, and both arms collect the same tests. The runtime patch applies with `patch --batch --forward --fuzz=0 -p1` on both bases.

The preview run uses the v0.29 parser-engine suite with three DeltaMessage imports adapted to the older module layout. Its seven remaining failures are identical before/after and to the September 13 run; they concern parser-manager wiring and turn-boundary behavior present in the newer suite. This is not a clean preview-suite pass.

Command: `.venv/bin/python -m pytest --confcutdir=tests/parser/engine tests/parser/engine -q --tb=short`.

This validates parser behavior, not a full image build, new model inference, or an agentic benchmark. AI assistance was used for implementation and validation; no human line-by-line review is claimed.
