### PR TITLE
COMPILE_CACHE: keep vLLM's compiled graphs across boots (-80s of init engine)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ one wins; anything below it stays an option.
 | fp8 KV cache (`KV_DTYPE=fp8_e4m3`) | option | ×1.9 KV pool, 1M context; −10% decode, −30% prefill, one scenario lost |
 | M%4 GEMM padding (`PAD_M4=1`) | option | no-op with prefix caching on; −40% TTFT at 8k with it off |
 | Exact `torch.topk` (`EXACT_TOPK=1`) | fallback | deterministic like the kernel, −20–40% long prefill |
+| Persistent compile cache (`COMPILE_CACHE`) | option | −80 s ± 2 s of init engine per boot after the first; startup only, outputs and tournament unaffected |
 | `--long-prefill-token-threshold` (via `EXTRA`) | option | keeps decoding clients responsive under concurrent prefills, at a TTFT cost |
 
 If your priority is raw throughput rather than the agent's reliability, the fast profile is
@@ -458,6 +459,45 @@ chunks:
 `PAD_M4=1` also sets `VLLM_FP8_PAD_M4=1`; `scripts/serve.sh` always passes the variable because
 the patch itself defaults to on when it is unset. NVFP4 mode does not use this GEMM.
 
+## Optional: persistent compile cache (`COMPILE_CACHE`)
+
+`scripts/serve.sh` recreates the container on every run (`docker rm -f`, then `docker run`), so
+vLLM's compiled graphs — written to `/root/.cache/vllm` inside the container — are discarded and
+rebuilt on every boot. If you keep one container and cycle it with `./flash stop` / `./flash start`
+this costs nothing, which is why it went unnoticed. It costs you when something else recreates the
+container for you: a proxy that loads and evicts models on demand (llama-swap and friends), CI, or
+a tournament run that calls `serve.sh` between configurations.
+
+`COMPILE_CACHE=<name>` mounts two docker volumes (`<name>-vllm`, `<name>-flashinfer`) over the two
+cache directories. `COMPILE_CACHE=/some/path` binds `/some/path/vllm` and `/some/path/flashinfer`
+instead, to put them on a chosen disk. Unset — the default — is exactly the behaviour above.
+
+Measured on a GX10, hybrid + YaRN 500k + MTP=2, same recipe each time. **Boot totals are not usable
+for this**: weight loading varied between 464 s and 554 s on page-cache state alone, and CUDA-graph
+capture between 4 s and 13 s, both larger than the effect being measured. The signal is in init
+engine with capture excluded, one row per boot:
+
+| boot | init engine | capture | init engine − capture | `torch.compile` |
+|---|---|---|---|---|
+| 1 — unset (default) | 129.2 s | 13 s | 116.2 s | 37.9 s |
+| 2 — set, populating | 125.5 s | 10 s | 115.5 s | 37.5 s |
+| 3 — set, reused | 41.1 s | 4 s | 37.1 s | 4.2 s |
+| 4 — set, reused, Triton volume emptied | 50.2 s | 13 s | 37.2 s | 0.7 s |
+| 5 — set, reused, final two-mount config | 37.3 s | 4 s | 33.3 s | 0.7 s |
+
+Reused (boots 3–5) is **35.9 s ± 2 s**, against **116.2 s** with the cache off: **−80 s ± 2 s
+(−69%)** per boot. Populating it costs nothing (boot 2 at 115.5 s against boot 1 at 116.2 s).
+Reused boots log `Directly load AOT compilation from path …`. Disk: 168 MB for the vLLM cache,
+0.5 MB for FlashInfer. Startup only — no effect on outputs, so nothing for the tournament to say.
+
+**Triton's `/root/.triton` is deliberately not persisted.** It looks like it should be the
+interesting one: `jit_monitor` warns that five kernels (`_qsa_mqa_paged_kernel`,
+`_qsa_sparse_paged_gqa_splitk`, `_compute_local_logits_stats_`, `_rejection_kernel`,
+`_resample_kernel`) JIT-compile *during the first request*. Boot 4 above tested it directly — vLLM
+cache warm, only the Triton volume emptied — and came out at 37.2 s against boot 3's 37.1 s: a
+0.2 s difference, an order of magnitude below the capture noise. The five warnings appear in every
+boot either way, warm or cold. Mounting it would have been cargo cult.
+
 ## Reduced draft vocabulary (`DRAFT_VOCAB=1`, default)
 
 vLLM shares the target model's `lm_head` with the MTP draft, so every draft step scores all
@@ -566,6 +606,7 @@ Full port notes in [docs/HOW-IT-WORKS.md](docs/HOW-IT-WORKS.md#the-vllm-v0290-po
 | `KV_DTYPE` | `auto` | `auto` = bf16 (recommended). `fp8_e4m3` = ~1.9× KV pool, 1M context on one box, at −10% decode / −30% prefill and a measurable quality cost — see [fp8 KV cache](docs/HOW-IT-WORKS.md#fp8-kv-cache-on-the-qsa-path-opt-in) before using it. |
 | `PREWARM` | `0` | `1` streams the 48 GiB table once at boot to warm the page cache — steadier first-request latency, ~10 s extra startup. |
 | `WORKERS` | `32` | Threads used for the mmap gather (only used above `VLLM_PLE_MMAP_FAST_ROWS`=512 unique rows; decode-sized gathers run inline). |
+| `COMPILE_CACHE` | | Keep vLLM's compiled graphs across boots — this script recreates the container every run, so by default they are rebuilt each time. `<name>` = two docker volumes, `/abs/path` = two bind mounts. **−80 s ± 2 s of init engine** per boot after the first, 169 MB of disk; only worth setting if something recreates the container for you (a model-swapping proxy, CI, tournament runs). See [above](#optional-persistent-compile-cache-compile_cache). |
 | `LOG_REQUESTS` | `0` | `1` logs every prompt and output (`VLLM_LOGGING_LEVEL=DEBUG --enable-log-requests --enable-log-outputs`) so `tools/vllm_watch.py` can show sessions live. Debugging only: it puts user content in the Docker log, unbounded. |
 | `EXTRA` | | Extra vLLM flags, passed verbatim — e.g. `--long-prefill-token-threshold 1024` for multi-client responsiveness (see [the concurrency section](#decoding-clients-stall-while-other-clients-prefill-the-long-prefill-token-threshold-slider)), `--api-key <secret>`. |
 

--- a/flash
+++ b/flash
@@ -224,7 +224,7 @@ cmd_serve() {
   local b; b="$(image_base)"
   [ -n "$b" ] && [ "$b" != "$BASE_EXPECTED" ] && die "$IMAGE is a '$b'-base image, profile '$profile' expects '$BASE_EXPECTED' — run: ./flash setup $profile"
   if [ "$(container_state)" = running ]; then info "$NAME is running and will be replaced"; fi
-  if [ "$DRY" = 1 ]; then info "dry run: would exec scripts/serve.sh with the environment above"; env | grep -E '^(MODE|IMAGE|NAME|PORT|CTX|YARN|MTP|SEQS|GPU_MEM|KV_DTYPE|PREFIX_CACHE|DET_TOPK|EXACT_TOPK|PAD_M4|DRAFT_VOCAB|MADVISE|PREWARM|EXTRA|BASE|LOG_REQUESTS|WORKERS)=' | sort | sed 's/^/    /'; return 0; fi
+  if [ "$DRY" = 1 ]; then info "dry run: would exec scripts/serve.sh with the environment above"; env | grep -E '^(MODE|IMAGE|NAME|PORT|CTX|YARN|MTP|SEQS|GPU_MEM|KV_DTYPE|PREFIX_CACHE|DET_TOPK|EXACT_TOPK|PAD_M4|DRAFT_VOCAB|MADVISE|PREWARM|COMPILE_CACHE|EXTRA|BASE|LOG_REQUESTS|WORKERS)=' | sort | sed 's/^/    /'; return 0; fi
   remember_profile "$profile"
   exec "$HERE/scripts/serve.sh"
 }

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -39,6 +39,10 @@
 #   PREWARM=0         1 = stream the 48 GiB table once at boot to warm the page cache
 #   WORKERS=32        threads for the mmap gather
 #   EXTRA=            extra vllm flags passed verbatim
+#   COMPILE_CACHE=    where to keep vLLM's compiled graphs and FlashInfer's JIT modules across
+#                     boots. Unset (default) = inside the container, which this script recreates
+#                     every time, so they are rebuilt on every boot (80 s of init engine, see
+#                     README). A bare name becomes docker volumes, an absolute path binds dirs
 #   IMAGE=qwen38-flash-dgx   MODEL=RadixArk/Qwen3.8-Flash-Next-NVFP4
 #   BASE=             preview|v0.29 — normally read from the image label (Dockerfile vs Dockerfile.v0.29).
 #                     On v0.29: KV_DTYPE must stay auto (fp8 KV not ported), PAD_M4 is a no-op.
@@ -65,6 +69,7 @@ MTP="${MTP:-2}"
 KV_DTYPE="${KV_DTYPE:-auto}"
 PREWARM="${PREWARM:-0}"
 EXTRA="${EXTRA:-}"
+COMPILE_CACHE="${COMPILE_CACHE:-}"
 
 # Resolve the local snapshot directory and map it to the in-container mount.
 REPO_DIR="$HF_CACHE/hub/models--${MODEL//\//--}"
@@ -151,6 +156,18 @@ LOGARGS=(); [ "$LOG_REQUESTS" = 1 ] && { DETENV+=(-e VLLM_LOGGING_LEVEL=DEBUG); 
 PC_ARG=--no-enable-prefix-caching
 [ "$PREFIX_CACHE" = 1 ] && PC_ARG=--enable-prefix-caching
 
+# Both are keyed by a hash of the model and the engine config, so one pair is safe to
+# share across profiles: a different recipe lands in a different entry. /root/.triton is
+# deliberately not persisted — measured at 0.2 s, below CUDA-graph capture noise.
+CACHE_MNT=()
+case "$COMPILE_CACHE" in
+  "") ;;
+  /*) CACHE_MNT=(-v "$COMPILE_CACHE/vllm:/root/.cache/vllm"
+                -v "$COMPILE_CACHE/flashinfer:/root/.cache/flashinfer") ;;
+  *)  CACHE_MNT=(-v "${COMPILE_CACHE}-vllm:/root/.cache/vllm"
+                -v "${COMPILE_CACHE}-flashinfer:/root/.cache/flashinfer") ;;
+esac
+
 docker rm -f "$NAME" >/dev/null 2>&1 || true
 # If docker run itself fails (port already bound, ...) do not leave a Created container behind.
 trap 'rc=$?; [ $rc -ne 0 ] && docker rm -f "$NAME" >/dev/null 2>&1; exit $rc' EXIT
@@ -158,6 +175,7 @@ trap 'rc=$?; [ $rc -ne 0 ] && docker rm -f "$NAME" >/dev/null 2>&1; exit $rc' EX
 docker run -d --name "$NAME" --restart unless-stopped \
   --gpus all --ipc=host --shm-size 16g -p "${PORT}:8000" \
   -v "$HF_CACHE:/hf" -e HF_HOME=/hf -e HF_HUB_OFFLINE=1 \
+  "${CACHE_MNT[@]}" \
   -e VLLM_PLE_MMAP=1 -e VLLM_PLE_MMAP_WORKERS="${WORKERS:-32}" -e VLLM_PLE_MMAP_PREWARM="$PREWARM" \
   -e VLLM_QSA_EXACT_TOPK="$EXACT_TOPK" "${DETENV[@]}" -e VLLM_FP8_PAD_M4="$PAD_M4" \
   -e VLLM_USE_FLASHINFER_SAMPLER=1 -e VLLM_ALLOW_LONG_MAX_MODEL_LEN="$ALLOW_LONG" \
@@ -189,6 +207,6 @@ case "$STATE" in
     ;;
 esac
 
-echo ">> $NAME starting on :$PORT (model 'qwen3.8-flash-next', mode=$MODE, ctx $CTX, yarn=$YARN, mtp=$MTP, seqs=$SEQS, prefix_cache=$PREFIX_CACHE, det_topk=$DET_TOPK, exact_topk=$EXACT_TOPK, pad_m4=$PAD_M4, draft_vocab=$DRAFT_VOCAB, madvise=$MADVISE)"
+echo ">> $NAME starting on :$PORT (model 'qwen3.8-flash-next', mode=$MODE, ctx $CTX, yarn=$YARN, mtp=$MTP, seqs=$SEQS, prefix_cache=$PREFIX_CACHE, det_topk=$DET_TOPK, exact_topk=$EXACT_TOPK, pad_m4=$PAD_M4, draft_vocab=$DRAFT_VOCAB, madvise=$MADVISE${COMPILE_CACHE:+, compile_cache=$COMPILE_CACHE})"
 echo ">> first boot loads ~76 GiB of weights (~8-13 min). Follow:  docker logs -f $NAME"
 echo ">> ready when the log says 'Application startup complete'. Then: scripts/smoke-test.sh"


### PR DESCRIPTION
`scripts/serve.sh` recreates the container on every run, so vLLM's compiled graphs — which live in `/root/.cache/vllm` inside it — are rebuilt on every boot. Invisible if you keep one container and cycle it with `./flash stop` / `start`, which I assume is why it hasn't come up. It costs a boot's worth of compilation when something else recreates the container for you: a proxy that loads and evicts models on demand (I hit this routing the recipe through llama-swap), CI, or a tournament run calling `serve.sh` between configurations.

`COMPILE_CACHE=<name>` mounts two docker volumes over the vLLM and FlashInfer cache directories; an absolute path binds directories under it instead, for putting them on a chosen disk. **Unset is the default and behaves exactly as before** — I've left it off rather than change a default in your project, though given the tournament re-runs `serve.sh` repeatedly you may want it on.

### Numbers

GX10, hybrid + YaRN 500k + MTP=2, same recipe each time. Boot totals are not usable for this: weight loading varied between 464 s and 554 s on page-cache state alone, and CUDA-graph capture between 4 s and 13 s, both larger than the effect. The signal is init engine with capture excluded, one row per boot:

| boot | init engine | capture | init engine − capture | `torch.compile` |
|---|---|---|---|---|
| 1 — unset (default) | 129.2 s | 13 s | 116.2 s | 37.9 s |
| 2 — set, populating | 125.5 s | 10 s | 115.5 s | 37.5 s |
| 3 — set, reused | 41.1 s | 4 s | 37.1 s | 4.2 s |
| 4 — set, reused, Triton volume emptied | 50.2 s | 13 s | 37.2 s | 0.7 s |
| 5 — set, reused, final two-mount config | 37.3 s | 4 s | 33.3 s | 0.7 s |

Reused (boots 3–5) is **35.9 s ± 2 s** against **116.2 s** with the cache off: **−80 s ± 2 s (−69%)** per boot. Populating costs nothing (boot 2 at 115.5 s vs boot 1 at 116.2 s). Reused boots log `Directly load AOT compilation from path …`. Disk: 168 MB vLLM + 0.5 MB FlashInfer. Startup only — outputs are untouched, so there's nothing for the tournament to say.

### Why `/root/.triton` is not mounted

`jit_monitor` warns that five kernels (`_qsa_mqa_paged_kernel`, `_qsa_sparse_paged_gqa_splitk`, `_compute_local_logits_stats_`, `_rejection_kernel`, `_resample_kernel`) JIT-compile *during the first request*, which looked like the bigger prize. Boot 4 tested it directly — vLLM cache warm, only the Triton volume emptied — at 37.2 s against boot 3's 37.1 s. 0.2 s, an order of magnitude below the capture noise, and the five warnings appear either way. Mounting it would have been cargo cult, so it isn't in the diff.

Boot 5 is the exact configuration in this PR, booted end to end and serving correctly.
